### PR TITLE
Add dynamic text color to Clock widget

### DIFF
--- a/R3E.YaHud/Components/Widget/Clock/Clock.razor
+++ b/R3E.YaHud/Components/Widget/Clock/Clock.razor
@@ -1,11 +1,11 @@
 ﻿@using R3E.YaHud.Components.Widget.Core
-@inherits HudWidgetBase<BasicSettings>
+@inherits HudWidgetBase<ClockSettings>
 @implements IDisposable
 
 @if (Settings.Visible)
 {
     <div id=@ElementId class="clock-widget" >
-        <span class="text">@currentTime.ToString("HH:mm:ss")</span>
+        <span class="text" style="color:@Settings.TextColor">@currentTime.ToString("HH:mm:ss")</span>
     </div>
 }
 

--- a/R3E.YaHud/Components/Widget/Clock/Clock.razor
+++ b/R3E.YaHud/Components/Widget/Clock/Clock.razor
@@ -5,7 +5,7 @@
 @if (Settings.Visible)
 {
     <div id=@ElementId class="clock-widget" >
-        <span class="text" style="color:@Settings.TextColor">@currentTime.ToString("HH:mm:ss")</span>
+        <span class="text" style="color: @Settings.TextColor">@currentTime.ToString("HH:mm:ss")</span>
     </div>
 }
 

--- a/R3E.YaHud/Components/Widget/Clock/Clock.razor.css
+++ b/R3E.YaHud/Components/Widget/Clock/Clock.razor.css
@@ -8,6 +8,5 @@
 }
 
 .text {
-    color: pink;
     font-size: 48px;
 }

--- a/R3E.YaHud/Components/Widget/Clock/ClockSettings.cs
+++ b/R3E.YaHud/Components/Widget/Clock/ClockSettings.cs
@@ -1,0 +1,12 @@
+﻿using R3E.YaHud.Components.Widget.Core;
+using R3E.YaHud.Services.Settings;
+
+namespace R3E.YaHud.Components.Widget.Clock
+{
+    public class ClockSettings : BasicSettings
+    {
+        [SettingType("Text Color", SettingsTypes.ColorPicker, 10,
+            ViewMode = SettingsViewMode.Intermediate)]
+        public string TextColor { get; set; } = "#FFFFFFFF";
+    }
+}


### PR DESCRIPTION
This pull request updates the Clock widget to support customizable text color via new settings. The main changes introduce a `ClockSettings` class with a `TextColor` property, update the widget to use these settings, and remove the previous hardcoded color from the CSS.

**Widget settings and customization:**

* Added a new `ClockSettings` class inheriting from `BasicSettings`, introducing a `TextColor` property with support for color picker in the settings UI.
* Updated `Clock.razor` to inherit from `HudWidgetBase<ClockSettings>` instead of `BasicSettings`, and applied the `TextColor` setting to the clock text using inline style.

**Styling changes:**

* Removed the hardcoded pink color from the `.text` CSS class in `Clock.razor.css`, so the color is now controlled by the new settings.Updated Clock.razor to use ClockSettings for dynamic text color customization. Removed default text color from Clock.razor.css to support this feature. Added ClockSettings.cs to define the new ClockSettings class with a TextColor property, allowing users to select a text color via a color picker.