### PR TITLE
Simplify DI service registration logic

### DIFF
--- a/R3E.YaHud/Program.cs
+++ b/R3E.YaHud/Program.cs
@@ -16,14 +16,14 @@ builder.Services.AddSingleton<ShortcutService>();
 if (OperatingSystem.IsWindows())
 {
     builder.Services.AddSingleton<SharedMemoryService>();
-    builder.Services.AddSingleton<ISharedSource>(sp => sp.GetRequiredService<SharedMemoryService>());
-    builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SharedMemoryService>());
+    builder.Services.AddSingleton<ISharedSource, SharedMemoryService>();
+    builder.Services.AddSingleton<IHostedService, SharedMemoryService>();
 }
 else
 {
     builder.Services.AddSingleton<RemoteSharedMemoryService>();
-    builder.Services.AddSingleton<ISharedSource>(sp => sp.GetRequiredService<RemoteSharedMemoryService>());
-    builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<RemoteSharedMemoryService>());
+    builder.Services.AddSingleton<ISharedSource, RemoteSharedMemoryService>();
+    builder.Services.AddSingleton<IHostedService, RemoteSharedMemoryService>();
 }
 
 // TelemetryService depends on ISharedSource. Let DI construct it so ILogger is injected.


### PR DESCRIPTION
This pull request refactors how dependency injection is configured for shared memory services in `Program.cs`. Instead of using factory methods to resolve services, it directly registers the implementation types for the relevant interfaces, simplifying the service registration and improving clarity.

Dependency injection improvements:

* Replaced factory-based service registrations with direct type registrations for `ISharedSource` and `IHostedService`, using `SharedMemoryService` on Windows and `RemoteSharedMemoryService` on other platforms in `Program.cs`.Refactor service registration in the DI container to directly specify implementation types for `ISharedSource` and `IHostedService`. Replace lambda-based service resolution with type-based registration for both Windows (`SharedMemoryService`) and non-Windows (`RemoteSharedMemoryService`) environments. Improves code clarity and maintainability.