### PR TITLE
Refactor branch validation in pre-push scripts

### DIFF
--- a/git/hooks/pre-push
+++ b/git/hooks/pre-push
@@ -18,7 +18,7 @@ valid_patterns=(
     "^dev$"
     "^development$"
     "^features?/.+"
-    "^hotfixes?/.+"
+    "^(hotfix|hotfixes)/.+"
 )
 
 # Check if branch name matches any valid pattern

--- a/git/hooks/pre-push.bat
+++ b/git/hooks/pre-push.bat
@@ -5,67 +5,59 @@ REM This hook prevents pushing branches that don't follow the naming pattern
 setlocal enabledelayedexpansion
 
 REM Get the current branch name
-for /f "delims=" %%i in ('git symbolic-ref --short HEAD 2^>nul') do set current_branch=%%i
+for /f "delims=" %%i in ('git symbolic-ref --short HEAD2^>nul') do set "current_branch=%%i"
 
 REM Check if we got a branch name
 if "%current_branch%"=="" (
-    echo Warning: Could not determine current branch
-    exit /b 0
+ echo Warning: Could not determine current branch
+ exit /b0
 )
 
-REM Define valid branch patterns and check
-set valid=0
+REM Initialize valid flag
+set "valid=0"
 
-REM Check main
-echo %current_branch% | findstr /r "^main$" >nul 2>&1
-if !errorlevel! equ 0 set valid=1
+REM Helper to test a regex against the branch name using findstr
+:check
+necho %current_branch% | findstr /r "%~1" >nul2>&1
+if %ERRORLEVEL% equ0 set "valid=1"
+ngoto :eof
 
-REM Check develop variants
-echo %current_branch% | findstr /r "^develop$" >nul 2>&1
-if !errorlevel! equ 0 set valid=1
-echo %current_branch% | findstr /r "^dev$" >nul 2>&1
-if !errorlevel! equ 0 set valid=1
-echo %current_branch% | findstr /r "^development$" >nul 2>&1
-if !errorlevel! equ 0 set valid=1
+REM Check allowed patterns
+call :check "^main$"
+call :check "^develop$"
+call :check "^dev$"
+call :check "^development$"
+call :check "^feature/.*"
+call :check "^features/.*"
+call :check "^hotfix/.*"
+call :check "^hotfixes/.*"
 
-REM Check feature branches
-echo %current_branch% | findstr /r "^feature/" >nul 2>&1
-if !errorlevel! equ 0 set valid=1
-echo %current_branch% | findstr /r "^features/" >nul 2>&1
-if !errorlevel! equ 0 set valid=1
-
-REM Check hotfix branches
-echo %current_branch% | findstr /r "^hotfix/" >nul 2>&1
-if !errorlevel! equ 0 set valid=1
-echo %current_branch% | findstr /r "^hotfixes/" >nul 2>&1
-if !errorlevel! equ 0 set valid=1
-
-if !valid! equ 0 (
-    echo.
-    echo ================================================================
-    echo   ERROR: INVALID BRANCH NAME
-    echo ================================================================
-    echo.
-    echo Branch name: %current_branch%
-    echo.
-    echo Valid branch naming patterns:
-    echo   - main
-    echo   - develop ^(or dev, development^)
-    echo   - feature/^<description^>  ^(e.g., feature/add-telemetry^)
-    echo   - features/^<description^> ^(e.g., features/widget/radar^)
-    echo   - hotfix/^<description^>   ^(e.g., hotfix/fix-crash^)
-    echo   - hotfixes/^<description^> ^(e.g., hotfixes/memory-leak^)
-    echo.
-    echo Examples:
-    echo   feature/add-radar-widget
-    echo   feature/ui/improve-dashboard
-    echo   hotfix/fix-telemetry-crash
-    echo.
-    echo To rename your branch:
-    echo   git branch -m %current_branch% feature/^<new-name^>
-    echo.
-    exit /b 1
+if "%valid%"=="0" (
+ echo.
+ echo ================================================================
+ echo ERROR: INVALID BRANCH NAME
+ echo ================================================================
+ echo.
+ echo Branch name: %current_branch%
+ echo.
+ echo Valid branch naming patterns:
+ echo - main
+ echo - develop ^(or dev, development^)
+ echo - feature/^<description^> ^(e.g., feature/add-telemetry^)
+ echo - features/^<description^> ^(e.g., features/widget/radar^)
+ echo - hotfix/^<description^> ^(e.g., hotfix/fix-crash^)
+ echo - hotfixes/^<description^> ^(e.g., hotfixes/memory-leak^)
+ echo.
+ echo Examples:
+ echo feature/add-radar-widget
+ echo feature/ui/improve-dashboard
+ echo hotfix/fix-telemetry-crash
+ echo.
+ echo To rename your branch:
+ echo git branch -m %current_branch% feature/^<new-name^>
+ echo.
+ exit /b1
 )
 
-echo [OK] Branch name is valid: %current_branch%
-exit /b 0
+necho [OK] Branch name is valid: %current_branch%
+exit /b0


### PR DESCRIPTION
This pull request updates the branch naming validation logic in both Unix (`pre-push`) and Windows (`pre-push.bat`) Git hooks. The main goal is to make the pattern matching for branch names more robust and maintainable, especially for hotfix branches. The Windows batch script also gets a refactor for better readability and reusability.

**Branch naming pattern updates:**

* Unified hotfix branch pattern in `git/hooks/pre-push` to match both `hotfix/` and `hotfixes/` prefixes using a single regular expression.

**Windows batch script refactor and improvements:**

* Refactored branch pattern checking in `git/hooks/pre-push.bat` by introducing a helper `:check` function to reduce repetition and make it easier to add new patterns.
* Updated the branch name validation to use more precise regular expressions, aligning with the Unix hook patterns.
* Improved error and status output handling for branch validation results.