### PR TITLE
Use explicit `this.logger` for clarity in ShortcutService

### DIFF
--- a/R3E.YaHud/Services/ShortcutService.cs
+++ b/R3E.YaHud/Services/ShortcutService.cs
@@ -22,7 +22,7 @@ namespace R3E.YaHud.Services
 
             // Run hook safely
             _ = hook.RunAsync();
-            logger.LogDebug("ShortcutService initialized");
+            this.logger.LogDebug("ShortcutService initialized");
         }
 
         private void OnKeyPressed(object? sender, KeyboardHookEventArgs e)


### PR DESCRIPTION
This pull request includes a minor update to the constructor of the `ShortcutService` class. The change ensures that the correct instance logger is used when logging initialization.

* Updated the logging statement in the `ShortcutService` constructor to use `this.logger` instead of the local `logger` parameter, ensuring that logs are consistently written using the intended logger instance.Updated the `logger.LogDebug` call in the `ShortcutService` class to explicitly use `this.logger` instead of `logger`. This change improves code readability and ensures clarity by explicitly referencing the instance variable, avoiding potential confusion with similarly named local variables or parameters.