### PR TITLE
Increase z-index of .overlay for higher stacking order

### DIFF
--- a/R3E.YaHud/wwwroot/app.css
+++ b/R3E.YaHud/wwwroot/app.css
@@ -84,7 +84,7 @@ h1:focus {
     display: flex;
     justify-content: center;
     align-items: center;
-    z-index: 1000;        
+    z-index: 9999;        
 }
 
 .overlay-panel {


### PR DESCRIPTION
This pull request makes a minor adjustment to the CSS for overlay elements, increasing their stacking order to ensure they appear above other elements.

* Increased the `z-index` of the `.overlay` selector from `1000` to `9999` in `app.css` to improve visibility and stacking priority. The `z-index` property of the `.overlay` CSS rule was updated from `1000` to `9999`. This ensures the element appears above other elements with lower `z-index` values, improving its visibility and layering behavior.