### PR TITLE
Adjust steering calculation for proper scaling

### DIFF
--- a/R3E.YaHud/Components/Widget/UserInputs/UserInputs.razor
+++ b/R3E.YaHud/Components/Widget/UserInputs/UserInputs.razor
@@ -78,7 +78,7 @@
         Clutch = (double)data.Clutch;
         Throttle = (double)data.Throttle;
         Brake = (double)data.Brake;
-        Steering = ((double)data.SteerInputRaw * (double)data.SteerWheelRangeDegrees).ToString().Replace(",", ".") + "deg";
+        Steering = (data.SteerInputRaw * data.SteerWheelRangeDegrees / 2).ToString().Replace(",", ".") + "deg";
     }
 
     protected override void UpdateWithTestData()


### PR DESCRIPTION
This pull request makes a minor adjustment to how the steering value is calculated and displayed in the `UserInputs.razor` component. The calculation for steering now divides the product of `SteerInputRaw` and `SteerWheelRangeDegrees` by 2 before converting it to a string.

- Changed the steering calculation in `UserInputs.razor` to divide the product of `SteerInputRaw` and `SteerWheelRangeDegrees` by 2 before formatting, likely to correct or standardize the displayed steering angle.The `Steering` property calculation has been updated. Previously, it was calculated as `data.SteerInputRaw * data.SteerWheelRangeDegrees`. The new calculation divides the result by 2, likely to adjust the scaling or normalization. This ensures the steering value is more accurately represented.