### PR TITLE
Feature/motec/rpm blink

### DIFF
--- a/R3E.YaHud/Components/Widget/MoTec/MoTec.razor
+++ b/R3E.YaHud/Components/Widget/MoTec/MoTec.razor
@@ -31,8 +31,8 @@
     private bool blinkModeOn = false;
     private string blinkColor = "#ff0000";
 
-    private const double MaxRpsOffset = 20.0;
-    private const double UpshiftRpsOffset = 70.0;
+    private const double MaxRpsOffset = 20.0; //Radians per Second 20 rad/s = 190.985932 RPM
+    private const double UpshiftRpsOffset = 70.0; //Radians per Second 70 rad/s = 668.450761 RPM
     private const double BlinkCycleDuration = 0.3;
     private const double BlinkOnDuration = 0.15;
 
@@ -86,14 +86,9 @@
             blinkModeOn = false;
         }
 
-        if (blinkModeOn)
-        {
-            RpsCurrentColor = (data.Player.GameSimulationTime % BlinkCycleDuration) < BlinkOnDuration ? blinkColor : Settings!.SecondaryBlinkColor;
-        }
-        else
-        {
-            RpsCurrentColor = Settings!.PrimaryColor;
-        }
+        RpsCurrentColor = blinkModeOn
+            ? ((data.Player.GameSimulationTime % BlinkCycleDuration) < BlinkOnDuration ? blinkColor : Settings!.SecondaryBlinkColor)
+            : Settings!.PrimaryColor;
     }
 
     protected override void UpdateWithTestData()

--- a/R3E.YaHud/Components/Widget/MoTec/MoTec.razor
+++ b/R3E.YaHud/Components/Widget/MoTec/MoTec.razor
@@ -6,8 +6,8 @@
 @if (Settings?.Visible ?? false)
 {
     <div id=@ElementId class="motec-widget text">
-        <p class="gear-text">@Gear</p>
-        <p class="speed-text">@Speed.ToString("0")</p>
+        <p class="gear-text" style="color:@RpsCurrentColor">@Gear</p>
+        <p class="speed-text" style="color:@RpsCurrentColor">@Speed.ToString("0")</p>
         <div class="rpm-component">
             <HorizontalBar @key="Rps"
                            Min="0.0d"
@@ -27,6 +27,14 @@
 
     private string RpsBarBackgroundColor => "#454545";
     private string RpsCurrentColor { get; set; } = "#ffffff";
+
+    private bool blinkModeOn = false;
+    private string blinkColor = "#ff0000";
+
+    private const double MaxRpsOffset = 20.0;
+    private const double UpshiftRpsOffset = 70.0;
+    private const double BlinkCycleDuration = 0.3;
+    private const double BlinkOnDuration = 0.15;
 
     public override string ElementId { get => "motecWidget"; }
     public override string Name => "MoTec";
@@ -60,10 +68,32 @@
         }
         Speed = UnitConverter.Convert(data.CarSpeed, SpeedUnit.MetersPerSecond, SettingsService.GlobalSettings.SpeedUnit);
         Rps = (double)data.EngineRps;
-        MaxRps = (double)data.MaxEngineRps;
-        var upshiftRps = (double)data.UpshiftRps;
+        MaxRps = (double)data.MaxEngineRps - MaxRpsOffset; // Slightly lower to give a better visual cue
+        var upshiftRps = (double)data.UpshiftRps - UpshiftRpsOffset; // Slightly lower to give a better visual cue
 
-        RpsCurrentColor = Rps >= upshiftRps ? Settings!.RpmUpshiftColor : Settings!.RpmColor;
+        if (Rps >= MaxRps)
+        {
+            blinkColor = Settings!.RpmMaxColor;
+            blinkModeOn = true;
+        }
+        else if (Rps >= upshiftRps)
+        {
+            blinkColor = Settings!.RpmUpshiftColor;
+            blinkModeOn = true;
+        }
+        else
+        {
+            blinkModeOn = false;
+        }
+
+        if (blinkModeOn)
+        {
+            RpsCurrentColor = (data.Player.GameSimulationTime % BlinkCycleDuration) < BlinkOnDuration ? blinkColor : Settings!.SecondaryBlinkColor;
+        }
+        else
+        {
+            RpsCurrentColor = Settings!.PrimaryColor;
+        }
     }
 
     protected override void UpdateWithTestData()

--- a/R3E.YaHud/Components/Widget/MoTec/MoTec.razor
+++ b/R3E.YaHud/Components/Widget/MoTec/MoTec.razor
@@ -58,7 +58,7 @@
                 Gear = data.Gear.ToString();
                 break;
         }
-        Speed = UnitConverter.Convert(data.CarSpeed, SpeedUnit.MilesPerHour, SettingsService.GlobalSettings.SpeedUnit);
+        Speed = UnitConverter.Convert(data.CarSpeed, SpeedUnit.MetersPerSecond, SettingsService.GlobalSettings.SpeedUnit);
         Rps = (double)data.EngineRps;
         MaxRps = (double)data.MaxEngineRps;
         var upshiftRps = (double)data.UpshiftRps;

--- a/R3E.YaHud/Components/Widget/MoTec/MoTecSettings.cs
+++ b/R3E.YaHud/Components/Widget/MoTec/MoTecSettings.cs
@@ -5,14 +5,24 @@ namespace R3E.YaHud.Components.Widget.MoTec
 {
     public class MoTecSettings : BasicSettings
     {
-        [SettingType("RPM Color", SettingsTypes.ColorPicker, 10,
-            Description = "Color of the RPM bar",
+        [SettingType("Primary Color", SettingsTypes.ColorPicker, 10,
+            Description = "Color of the RPM bar and gear indicator",
             ViewMode = SettingsViewMode.Intermediate)]
-        public string RpmColor { get; set; } = "#0069ff";
+        public string PrimaryColor { get; set; } = "#0069ff";
 
         [SettingType("RPM Redline Color", SettingsTypes.ColorPicker, 11,
             Description = "Color of the RPM bar when in the redline zone",
             ViewMode = SettingsViewMode.Intermediate)]
         public string RpmUpshiftColor { get; set; } = "#ff006a";
+
+        [SettingType("RPM Max Color", SettingsTypes.ColorPicker, 12,
+            Description = "Color of the RPM bar when at maximum RPM",
+            ViewMode = SettingsViewMode.Intermediate)]
+        public string RpmMaxColor { get; set; } = "#ff0000";
+
+        [SettingType("RPM Blink Color", SettingsTypes.ColorPicker, 13,
+            Description = "Color of the RPM bar when blinking",
+            ViewMode = SettingsViewMode.Intermediate)]
+        public string SecondaryBlinkColor { get; set; } = "#5e5e5e";
     }
 }


### PR DESCRIPTION
This pull request enhances the MoTec widget by introducing a dynamic color-blinking effect for the gear and speed indicators based on engine RPM, and expands the customization options in the widget's settings. The changes aim to provide clearer visual cues for upshift and maximum RPM situations, improving user awareness during gameplay.

**Visual and Functional Enhancements:**

* Added a blinking effect to the gear and speed text when engine RPM exceeds upshift or maximum thresholds, using configurable colors and timing logic. The color alternates between a warning color and a secondary blink color based on the simulation time. [[1]](diffhunk://#diff-c7989602412b04de751938b0a5f1cdccdc4bd884ab36b4e28f8468b46802a0dbL9-R10) [[2]](diffhunk://#diff-c7989602412b04de751938b0a5f1cdccdc4bd884ab36b4e28f8468b46802a0dbL61-R96)
* Adjusted the calculation of `MaxRps` and `upshiftRps` to use slightly lower values, providing earlier and clearer visual cues for the user.
* Fixed speed conversion to use meters per second as the base unit.

**Settings and Customization Improvements:**

* Renamed the `RpmColor` setting to `PrimaryColor` and updated its description to reflect its broader use for both the RPM bar and gear indicator.
* Added new customizable color settings: `RpmMaxColor` (for maximum RPM), and `SecondaryBlinkColor` (for the blink effect), allowing users to tailor the visual alerts to their preferences.
* Introduced new private fields and constants in `MoTec.razor` to support the blinking logic and color configuration.