### PR TITLE
Disable prerendering

### DIFF
--- a/R3E.YaHud/Components/App.razor
+++ b/R3E.YaHud/Components/App.razor
@@ -21,10 +21,10 @@
     <link rel="stylesheet" href="assets/coloris/css/coloris.css" />
     <ImportMap />
     <link rel="icon" type="image/png" href="favicon.png" />
-    <HeadOutlet @rendermode="InteractiveServer" />
+    <HeadOutlet @rendermode="new InteractiveServerRenderMode(prerender: false)" />
 </head>
 <body class="@CurrentFont no-select">
-    <Routes @rendermode="InteractiveServer" />
+    <Routes @rendermode="new InteractiveServerRenderMode(prerender: false)" />
     <script src="js/HudHelper.js"></script>
     <script defer src="assets/coloris/js/coloris.js"></script>
     <script defer src="assets/fontawesome/js/fontawesome.js"></script>


### PR DESCRIPTION
This pull request makes a minor update to how interactive rendering is configured in the `App.razor` component. Instead of using the default `InteractiveServer` render mode, it now explicitly disables prerendering by passing `prerender: false` to `InteractiveServerRenderMode`. This ensures that both the `<HeadOutlet>` and `<Routes>` components are rendered interactively on the server without prerendering. So the Widget are not instantiated two times. One time for pre render server side and another for the client. 

- Rendering configuration:
  * Updated the `@rendermode` for both `<HeadOutlet>` and `<Routes>` components to use `new InteractiveServerRenderMode(prerender: false)`, explicitly disabling prerendering.Updated the @rendermode attribute for the <HeadOutlet> and <Routes> components to use `new InteractiveServerRenderMode` with `prerender: false`. This change ensures that prerendering is disabled for these components.