### PR TITLE
Add accessibility guidelines for widgets

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,15 @@ public class FuelWidget : WidgetBase
 }
 ```
 
+### Accessibility for Widgets
+
+Widgets in this project are not intended to be consumed by screen readers. As a result:
+
+- Do not add `aria-*` attributes to widget HTML/Razor markup.
+- Do not add `role` attributes to widget HTML/Razor markup.
+- Avoid attributes like `aria-label`, `aria-hidden`, `role`, etc. inside widgets.
+
+
 ### Summary
 
 | Responsibility | Location |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,7 +104,6 @@ Widgets in this project are not intended to be consumed by screen readers. As a 
 
 - Do not add `aria-*` attributes to widget HTML/Razor markup.
 - Do not add `role` attributes to widget HTML/Razor markup.
-- Avoid attributes like `aria-label`, `aria-hidden`, `role`, etc. inside widgets.
 
 
 ### Summary


### PR DESCRIPTION
This pull request updates the documentation for widget accessibility guidelines in `.github/copilot-instructions.md`. The main change is the addition of a new section clarifying that widgets in this project are not meant for screen reader consumption and specifying which accessibility-related attributes should be avoided.

Documentation update:

* Added an "Accessibility for Widgets" section to clarify that widgets should not include `aria-*` or `role` attributes, nor other accessibility-related attributes such as `aria-label` or `aria-hidden`.Added a new "Accessibility for Widgets" section to the `copilot-instructions.md` file. This section clarifies that widgets are not intended for screen reader use and provides guidelines to avoid adding accessibility-related attributes (e.g., `aria-*`, `role`, `aria-label`, `aria-hidden`) to widget HTML/Razor markup.