### PR TITLE
Updated Copilot instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,15 @@ public class FuelWidget : WidgetBase
 }
 ```
 
+### Accessibility for Widgets
+
+Widgets in this project are not intended to be consumed by screen readers. As a result:
+
+- Do not add `aria-*` attributes to widget HTML/Razor markup.
+- Do not add `role` attributes to widget HTML/Razor markup.
+- Avoid attributes like `aria-label`, `aria-hidden`, `role`, etc. inside widgets.
+
+
 ### Summary
 
 | Responsibility | Location |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,7 +104,6 @@ Widgets in this project are not intended to be consumed by screen readers. As a 
 
 - Do not add `aria-*` attributes to widget HTML/Razor markup.
 - Do not add `role` attributes to widget HTML/Razor markup.
-- Avoid attributes like `aria-label`, `aria-hidden`, `role`, etc. inside widgets.
 
 
 ### Summary


### PR DESCRIPTION
This pull request adds a new accessibility guideline for widgets to the documentation, clarifying how accessibility attributes should be handled.

Documentation update—Accessibility:

* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R101-R108): Added a section specifying that widgets in this project are not intended for screen readers, and instructing developers not to add `aria-*` or `role` attributes to widget HTML/Razor markup.