### PR TITLE
Remove ARIA attributes from bar and start light components

### DIFF
--- a/R3E.YaHud/Components/Widget/MoTec/Components/HorizontalBar.razor
+++ b/R3E.YaHud/Components/Widget/MoTec/Components/HorizontalBar.razor
@@ -15,9 +15,9 @@
     [Parameter] public string PrimaryColor { get; set; } = "white";
     [Parameter] public string BackgroundColor { get; set; } = "darkgray";
 
-    string Percent => 
-        Max == Min 
-            ? "0%" 
+    string Percent =>
+        Max == Min
+            ? "0%"
             : (Math.Clamp((Value - Min) / (Max - Min) * 100.0, 0.0, 100.0)
                 .ToString("0.##")
                 .Replace(",", ".") + "%");

--- a/R3E.YaHud/Components/Widget/StartLight/StartLight.razor
+++ b/R3E.YaHud/Components/Widget/StartLight/StartLight.razor
@@ -6,7 +6,7 @@
 {
     <div style="display: @(IsCountdownPhase || TestMode ? "block" : "none");">
         <div id=@ElementId class="start-light-widget text">
-            <div class="lights-and-glows-container" aria-label="Start lights (countdown)">
+            <div class="lights-and-glows-container">
                 <div class="lights-container">
                     @for (int i = 1; i <= 5; i++)
                     {
@@ -97,15 +97,15 @@
         {
             case R3E.Constant.SessionPhase.Countdown:
             case R3E.Constant.SessionPhase.Formation:
-            IsCountdownPhase = true;
+                IsCountdownPhase = true;
                 break;
             case R3E.Constant.SessionPhase.Green:
-            IsCountdownPhase = (PlayerControl != Constant.Control.Player && TelemetryService.Data.RollingStart)
-                ? true
-                : IsStartPeriodActive();
+                IsCountdownPhase = (PlayerControl != Constant.Control.Player && TelemetryService.Data.RollingStart)
+                    ? true
+                    : IsStartPeriodActive();
                 break;
             default:
-            IsCountdownPhase = false;
+                IsCountdownPhase = false;
                 break;
         }
 

--- a/R3E.YaHud/Components/Widget/UserInputs/Components/HorizontalBar.razor
+++ b/R3E.YaHud/Components/Widget/UserInputs/Components/HorizontalBar.razor
@@ -1,4 +1,4 @@
-<div class="horizontal-bar" role="progressbar" aria-valuenow="@Value" aria-valuemin="-1" aria-valuemax="1">
+<div class="horizontal-bar">
     <div class="horizontal-bar-track" style="background-color:@BackgroundColor">
         <div class="horizontal-bar-dot" style="left:@Percent; background-color:@PrimaryColor"></div>
     </div>

--- a/R3E.YaHud/Components/Widget/UserInputs/Components/VerticalBar.razor
+++ b/R3E.YaHud/Components/Widget/UserInputs/Components/VerticalBar.razor
@@ -1,4 +1,4 @@
-﻿<div class="vertical-bar" role="progressbar" aria-label="value: @Percent">
+﻿<div class="vertical-bar">
     <div class="vertical-bar-track" style="background-color:@BackgroundColor">
         <div class="vertical-bar-fill" style="height:@Percent; background-color:@PrimaryColor"></div>
     </div>


### PR DESCRIPTION
This pull request removes certain accessibility-related attributes (such as ARIA labels and roles) from several UI components, likely to simplify the markup or address accessibility concerns. The changes affect the start light widget and user input bar components.

Accessibility attribute removals:

* Removed the `aria-label` attribute from the `lights-and-glows-container` div in `StartLight.razor`.
* Removed `role="progressbar"` and related ARIA attributes (`aria-valuenow`, `aria-valuemin`, `aria-valuemax`) from the root div in `HorizontalBar.razor`.
* Removed `role="progressbar"` and the `aria-label` attribute from the root div in `VerticalBar.razor`.Removed ARIA accessibility attributes from HorizontalBar, VerticalBar, and StartLight components, simplifying the rendered HTML. Also  adjusted code indentation in StartLight for consistency. No changes to component logic.