### PR TITLE
User input pedal show Actual input

### DIFF
--- a/R3E.YaHud/Components/Widget/UserInputs/Components/VerticalBar.razor
+++ b/R3E.YaHud/Components/Widget/UserInputs/Components/VerticalBar.razor
@@ -16,7 +16,7 @@
     [Parameter] public double Value { get; set; } = 0;
     [Parameter] public string PrimaryColor { get; set; } = "white";
     [Parameter] public string BackgroundColor { get; set; } = "darkgray";
-    [Parameter] public string? DiffColor { get; set; } = "lightgray";
+    [Parameter] public string DiffColor { get; set; } = "lightgray";
 
     string PercentRaw =>
         Max == Min
@@ -29,10 +29,7 @@
     {
         get
         {
-            if (ValueRaw < 0.001)
-            {
-                return "0%";
-            }
+            if (ValueRaw < 0.01) return "0%";
 
             return Math.Clamp((ValueRaw - Value) / ValueRaw * 100.0, 0.0, 100.0)
             .ToString("0.##")

--- a/R3E.YaHud/Components/Widget/UserInputs/Components/VerticalBar.razor
+++ b/R3E.YaHud/Components/Widget/UserInputs/Components/VerticalBar.razor
@@ -1,10 +1,11 @@
 ﻿<div class="vertical-bar">
     <div class="vertical-bar-track" style="background-color:@BackgroundColor">
-        <div class="vertical-bar-fill-raw" style="height:@PercentRaw; background-color:@PrimaryColor"></div>
-        @if (Value < ValueRaw)
-        {
-            <div class="vertical-bar-fill-diff" style="height:@PercentDiff; bottom:@Percent; background-color:@DiffColor"></div>
-        }
+        <div class="vertical-bar-fill-raw" style="height:@PercentRaw; background-color:@PrimaryColor">
+            @if (Value < ValueRaw)
+            {
+                <div class="vertical-bar-fill-diff" style="height:@PercentDiffRelative; background-color:@DiffColor"></div>
+            }
+        </div>
     </div>
 </div>
 
@@ -15,7 +16,7 @@
     [Parameter] public double Value { get; set; } = 0;
     [Parameter] public string PrimaryColor { get; set; } = "white";
     [Parameter] public string BackgroundColor { get; set; } = "darkgray";
-    [Parameter] public string? DiffColor { get; set; } = "lightgreen";
+    [Parameter] public string? DiffColor { get; set; } = "lightgray";
 
     string PercentRaw =>
         Max == Min
@@ -24,17 +25,18 @@
                 .ToString("0.##")
                 .Replace(",", ".") + "%");
 
-    string Percent =>
-        Max == Min
-            ? "0%"
-            : (Math.Clamp((Value - Min) / (Max - Min) * 100.0, 0.0, 100.0)
-                .ToString("0.##")
-                .Replace(",", ".") + "%");
+    string PercentDiffRelative
+    {
+        get
+        {
+            if (ValueRaw < 0.001)
+            {
+                return "0%";
+            }
 
-    string PercentDiff =>
-        Max == Min
-            ? "0%"
-            : (Math.Clamp((ValueRaw - Value) / (Max - Min) * 100.0, 0.0, 100.0)
-                .ToString("0.##")
-                .Replace(",", ".") + "%");
+            return Math.Clamp((ValueRaw - Value) / ValueRaw * 100.0, 0.0, 100.0)
+            .ToString("0.##")
+            .Replace(",", ".") + "%";
+        }
+    }
 }

--- a/R3E.YaHud/Components/Widget/UserInputs/Components/VerticalBar.razor
+++ b/R3E.YaHud/Components/Widget/UserInputs/Components/VerticalBar.razor
@@ -1,20 +1,40 @@
 ﻿<div class="vertical-bar">
     <div class="vertical-bar-track" style="background-color:@BackgroundColor">
-        <div class="vertical-bar-fill" style="height:@Percent; background-color:@PrimaryColor"></div>
+        <div class="vertical-bar-fill-raw" style="height:@PercentRaw; background-color:@PrimaryColor"></div>
+        @if (Value < ValueRaw)
+        {
+            <div class="vertical-bar-fill-diff" style="height:@PercentDiff; bottom:@Percent; background-color:@DiffColor"></div>
+        }
     </div>
 </div>
 
 @code {
     [Parameter] public double Min { get; set; } = 0;
     [Parameter] public double Max { get; set; } = 100;
-    [Parameter] public double Value { get; set; }
+    [Parameter] public double ValueRaw { get; set; } = 0;
+    [Parameter] public double Value { get; set; } = 0;
     [Parameter] public string PrimaryColor { get; set; } = "white";
     [Parameter] public string BackgroundColor { get; set; } = "darkgray";
+    [Parameter] public string? DiffColor { get; set; } = "lightgreen";
+
+    string PercentRaw =>
+        Max == Min
+            ? "0%"
+            : (Math.Clamp((ValueRaw - Min) / (Max - Min) * 100.0, 0.0, 100.0)
+                .ToString("0.##")
+                .Replace(",", ".") + "%");
 
     string Percent =>
         Max == Min
             ? "0%"
             : (Math.Clamp((Value - Min) / (Max - Min) * 100.0, 0.0, 100.0)
+                .ToString("0.##")
+                .Replace(",", ".") + "%");
+
+    string PercentDiff =>
+        Max == Min
+            ? "0%"
+            : (Math.Clamp((ValueRaw - Value) / (Max - Min) * 100.0, 0.0, 100.0)
                 .ToString("0.##")
                 .Replace(",", ".") + "%");
 }

--- a/R3E.YaHud/Components/Widget/UserInputs/Components/VerticalBar.razor.css
+++ b/R3E.YaHud/Components/Widget/UserInputs/Components/VerticalBar.razor.css
@@ -15,7 +15,6 @@
     border-radius: 4px;
     overflow: hidden;
     box-sizing: border-box;
-    position: relative;
 }
 
 .vertical-bar-fill-raw {
@@ -24,14 +23,9 @@
     transition: height;
     box-sizing: border-box;
     align-self: stretch;
-}
-
-.vertical-bar-fill {
-    width: 100%;
-    height: 0%;
-    transition: height;
-    box-sizing: border-box;
-    align-self: stretch;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
 }
 
 .vertical-bar-fill-diff {
@@ -39,8 +33,4 @@
     height: 0%;
     transition: height;
     box-sizing: border-box;
-    align-self: stretch;
-    position: absolute;
-    bottom: 0;
-    left: 0;
 }

--- a/R3E.YaHud/Components/Widget/UserInputs/Components/VerticalBar.razor.css
+++ b/R3E.YaHud/Components/Widget/UserInputs/Components/VerticalBar.razor.css
@@ -15,12 +15,32 @@
     border-radius: 4px;
     overflow: hidden;
     box-sizing: border-box;
+    position: relative;
+}
+
+.vertical-bar-fill-raw {
+    width: 100%;
+    height: 0%;
+    transition: height;
+    box-sizing: border-box;
+    align-self: stretch;
 }
 
 .vertical-bar-fill {
     width: 100%;
     height: 0%;
-    transition: height 120ms linear;
+    transition: height;
     box-sizing: border-box;
     align-self: stretch;
+}
+
+.vertical-bar-fill-diff {
+    width: 100%;
+    height: 0%;
+    transition: height;
+    box-sizing: border-box;
+    align-self: stretch;
+    position: absolute;
+    bottom: 0;
+    left: 0;
 }

--- a/R3E.YaHud/Components/Widget/UserInputs/UserInputs.razor
+++ b/R3E.YaHud/Components/Widget/UserInputs/UserInputs.razor
@@ -10,30 +10,42 @@
             @if (Settings.ShowClutch)
             {
                 <div class="clutch-component">
-                    <p class="value-label">@((int)(Clutch * 100))</p>
+                    @if (Settings.ShowPedalValues)
+                    {
+                        <p class="value-label">@((int)(ClutchRaw * 100))</p>
+                    }
                     <VerticalBar @key="Clutch"
                                  Min="0.0d"
                                  Max="1.0d"
                                  Value="@Clutch"
+                                 ValueRaw="@ClutchRaw"
                                  PrimaryColor="@Settings.ClutchColor"
                                  BackgroundColor="@BarBackgroundColor" />
                 </div>
             }
             <div class="brake-component">
-                <p class="value-label">@((int)(Brake * 100))</p>
+                @if (Settings.ShowPedalValues)
+                {
+                    <p class="value-label">@((int)(BrakeRaw * 100))</p>
+                }
                 <VerticalBar @key="Brake"
                              Min="0.0d"
                              Max="1.0d"
                              Value="@Brake"
+                             ValueRaw="@BrakeRaw"
                              PrimaryColor="@Settings.BrakeColor"
                              BackgroundColor="@BarBackgroundColor" />
             </div>
             <div class="throttle-component">
-                <p class="value-label">@((int)(Throttle * 100))</p>
+                @if (Settings.ShowPedalValues)
+                {
+                    <p class="value-label">@((int)(ThrottleRaw * 100))</p>
+                }
                 <VerticalBar @key="Throttle"
                              Min="0.0d"
                              Max="1.0d"
                              Value="@Throttle"
+                             ValueRaw="@ThrottleRaw"
                              PrimaryColor="@Settings.ThrottleColor"
                              BackgroundColor="@BarBackgroundColor" />
             </div>
@@ -59,8 +71,11 @@
 }
 
 @code {
+    private double ClutchRaw { get; set; } = 0.0d;
     private double Clutch { get; set; } = 0.0d;
+    private double ThrottleRaw { get; set; } = 0.0d;
     private double Throttle { get; set; } = 0.0d;
+    private double BrakeRaw { get; set; } = 0.0d;
     private double Brake { get; set; } = 0.0d;
     private string SteeringWheelDeg { get; set; } = "0deg";
     private double SteeringInputRaw { get; set; } = 0.0d;
@@ -86,18 +101,24 @@
     {
         R3E.Data.Shared data = TelemetryService.Data.Raw;
 
-        Clutch = (double)data.ClutchRaw;
-        Throttle = (double)data.ThrottleRaw;
-        Brake = (double)data.BrakeRaw;
+        ClutchRaw = (double)data.ClutchRaw;
+        Clutch = (double)data.Clutch;
+        ThrottleRaw = (double)data.ThrottleRaw;
+        Throttle = (double)data.Throttle;
+        BrakeRaw = (double)data.BrakeRaw;
+        Brake = (double)data.Brake;
         SteeringInputRaw = data.SteerInputRaw;
         SteeringWheelDeg = (data.SteerInputRaw * data.SteerWheelRangeDegrees / 2).ToString().Replace(",", ".") + "deg";
     }
 
     protected override void UpdateWithTestData()
     {
-        Clutch = 0.35;
-        Throttle = 0.85;
-        Brake = 0.15;
+        ClutchRaw = 0.35;
+        Clutch = ClutchRaw;
+        ThrottleRaw = 0.85;
+        Throttle = 0.50;
+        BrakeRaw = 0.15;
+        Brake = BrakeRaw;
         SteeringWheelDeg = "45deg";
         SteeringInputRaw = 0.5;
     }

--- a/R3E.YaHud/Components/Widget/UserInputs/UserInputs.razor
+++ b/R3E.YaHud/Components/Widget/UserInputs/UserInputs.razor
@@ -20,6 +20,7 @@
                                  Value="@Clutch"
                                  ValueRaw="@ClutchRaw"
                                  PrimaryColor="@Settings.ClutchColor"
+                                 DiffColor="@Settings.DiffColor"
                                  BackgroundColor="@BarBackgroundColor" />
                 </div>
             }
@@ -34,6 +35,7 @@
                              Value="@Brake"
                              ValueRaw="@BrakeRaw"
                              PrimaryColor="@Settings.BrakeColor"
+                             DiffColor="@Settings.DiffColor"
                              BackgroundColor="@BarBackgroundColor" />
             </div>
             <div class="throttle-component">
@@ -47,6 +49,7 @@
                              Value="@Throttle"
                              ValueRaw="@ThrottleRaw"
                              PrimaryColor="@Settings.ThrottleColor"
+                             DiffColor="@Settings.DiffColor"
                              BackgroundColor="@BarBackgroundColor" />
             </div>
         </div>
@@ -102,11 +105,22 @@
         R3E.Data.Shared data = TelemetryService.Data.Raw;
 
         ClutchRaw = (double)data.ClutchRaw;
-        Clutch = (double)data.Clutch;
         ThrottleRaw = (double)data.ThrottleRaw;
-        Throttle = (double)data.Throttle;
         BrakeRaw = (double)data.BrakeRaw;
-        Brake = (double)data.Brake;
+
+        if (!Settings!.ShowPedalDiff)
+        {
+            Clutch = ClutchRaw;
+            Brake = BrakeRaw;
+            Throttle = ThrottleRaw;
+        }
+        else
+        {
+            Clutch = (double)data.Clutch;
+            Brake = (double)data.Brake;
+            Throttle = (double)data.Throttle;
+        }
+
         SteeringInputRaw = data.SteerInputRaw;
         SteeringWheelDeg = (data.SteerInputRaw * data.SteerWheelRangeDegrees / 2).ToString().Replace(",", ".") + "deg";
     }
@@ -114,11 +128,22 @@
     protected override void UpdateWithTestData()
     {
         ClutchRaw = 0.35;
-        Clutch = ClutchRaw;
-        ThrottleRaw = 0.85;
-        Throttle = 0.50;
         BrakeRaw = 0.15;
-        Brake = BrakeRaw;
+        ThrottleRaw = 0.85;
+
+        if (!Settings!.ShowPedalDiff)
+        {
+            Clutch = ClutchRaw;
+            Brake = BrakeRaw;
+            Throttle = ThrottleRaw;
+        }
+        else
+        {
+            Clutch = ClutchRaw - 0.15;
+            Throttle = ThrottleRaw - 0.35;
+            Brake = BrakeRaw - 0.05;
+        }
+
         SteeringWheelDeg = "45deg";
         SteeringInputRaw = 0.5;
     }

--- a/R3E.YaHud/Components/Widget/UserInputs/UserInputsSettings.cs
+++ b/R3E.YaHud/Components/Widget/UserInputs/UserInputsSettings.cs
@@ -151,7 +151,7 @@ namespace R3E.YaHud.Components.Widget.UserInputs
 
         private bool showPedalDiff = true;
         [SettingType("Show diff of pedal input", SettingsTypes.Checkbox, 25,
-            Description = "Show diff of pedal input and the ingame pedal input after TC and ABS",
+            Description = "Show difference between raw pedal input and in-game pedal values after TC and ABS",
             ViewMode = SettingsViewMode.Intermediate)]
         public bool ShowPedalDiff
         {
@@ -164,9 +164,9 @@ namespace R3E.YaHud.Components.Widget.UserInputs
             }
         }
 
-        private string diffColor = "000000bf";
+        private string diffColor = "#000000bf";
         [SettingType("Pedal diff Color", SettingsTypes.ColorPicker, 26,
-            Description = "Color when there is a difference between Pedal raw and actual pedal value",
+            Description = "Color of the difference between raw and processed pedal input",
             ViewMode = SettingsViewMode.Expert)]
         public string DiffColor
         {

--- a/R3E.YaHud/Components/Widget/UserInputs/UserInputsSettings.cs
+++ b/R3E.YaHud/Components/Widget/UserInputs/UserInputsSettings.cs
@@ -69,6 +69,22 @@ namespace R3E.YaHud.Components.Widget.UserInputs
             }
         }
 
+        private bool showPedalValues = true;
+
+        [SettingType("Show Pedal Values", SettingsTypes.Checkbox, 14,
+        Description = "Show throttle/brake input values",
+        ViewMode = SettingsViewMode.Intermediate)]
+        public bool ShowPedalValues
+        {
+            get => showPedalValues;
+            set
+            {
+                if (value == showPedalValues) return;
+                showPedalValues = value;
+                NotifyPropertyChanged();
+            }
+        }
+
         private bool showClutch = true;
 
         [SettingType("Show Clutch", SettingsTypes.Checkbox, 15,

--- a/R3E.YaHud/Components/Widget/UserInputs/UserInputsSettings.cs
+++ b/R3E.YaHud/Components/Widget/UserInputs/UserInputsSettings.cs
@@ -73,7 +73,7 @@ namespace R3E.YaHud.Components.Widget.UserInputs
 
         [SettingType("Show Pedal Values", SettingsTypes.Checkbox, 14,
         Description = "Show throttle/brake input values",
-        ViewMode = SettingsViewMode.Intermediate)]
+        ViewMode = SettingsViewMode.Beginner)]
         public bool ShowPedalValues
         {
             get => showPedalValues;
@@ -144,6 +144,37 @@ namespace R3E.YaHud.Components.Widget.UserInputs
             {
                 if (value == brakeColor) return;
                 brakeColor = value;
+                NotifyPropertyChanged();
+            }
+        }
+
+
+        private bool showPedalDiff = true;
+        [SettingType("Show diff of pedal input", SettingsTypes.Checkbox, 25,
+            Description = "Show diff of pedal input and the ingame pedal input after TC and ABS",
+            ViewMode = SettingsViewMode.Intermediate)]
+        public bool ShowPedalDiff
+        {
+            get => showPedalDiff;
+            set
+            {
+                if (value == showPedalDiff) return;
+                showPedalDiff = value;
+                NotifyPropertyChanged();
+            }
+        }
+
+        private string diffColor = "000000bf";
+        [SettingType("Pedal diff Color", SettingsTypes.ColorPicker, 26,
+            Description = "Color when there is a difference between Pedal raw and actual pedal value",
+            ViewMode = SettingsViewMode.Expert)]
+        public string DiffColor
+        {
+            get => diffColor;
+            set
+            {
+                if (value == diffColor) return;
+                diffColor = value;
                 NotifyPropertyChanged();
             }
         }


### PR DESCRIPTION
This pull request enhances the user input widget by adding support for displaying the difference between raw pedal inputs and the in-game processed pedal values (after traction control and ABS). It introduces new settings for showing pedal values, displaying pedal input differences, and customizing the diff color. The UI and logic for the vertical bar component have been updated to visually represent these differences.

**User Input Diff Visualization:**

* The `VerticalBar` component now supports displaying both raw and processed pedal values, and visually highlights the difference between them using a separate fill and customizable color. [[1]](diffhunk://#diff-23eda26b901f29e542f48966444b72573555d39006ff48ecbf745199ba00a5e9L3-R41) [[2]](diffhunk://#diff-31279169e33edad9a8ce51d4fa6746e4a0d19cdbb6764f4febc1935ae304e1c4L20-R35)
* The `UserInputs.razor` component passes both raw and processed values to `VerticalBar`, and conditionally displays value labels and diff bars based on new settings. [[1]](diffhunk://#diff-60ff8d3b9bdc4cf2163846b182eae84122da6c2e74d42f4a6a1bcd2b631e9396L13-R52) [[2]](diffhunk://#diff-60ff8d3b9bdc4cf2163846b182eae84122da6c2e74d42f4a6a1bcd2b631e9396R77-R81) [[3]](diffhunk://#diff-60ff8d3b9bdc4cf2163846b182eae84122da6c2e74d42f4a6a1bcd2b631e9396L89-R146)

**New Settings for Customization:**

* Added `ShowPedalValues` (beginner), `ShowPedalDiff` (intermediate), and `DiffColor` (expert) settings to `UserInputsSettings`, allowing users to control visibility and appearance of pedal value and diff displays. [[1]](diffhunk://#diff-ffba6988e0ab24d75f05436e6ea531fc21ccffe4117362064e30cad36c18205aR72-R87) [[2]](diffhunk://#diff-ffba6988e0ab24d75f05436e6ea531fc21ccffe4117362064e30cad36c18205aR151-R181)