### PR TITLE
Suppress CA1416 warnings for Windows service registration

### DIFF
--- a/R3E.YaHud/Program.cs
+++ b/R3E.YaHud/Program.cs
@@ -50,7 +50,6 @@ if (OperatingSystem.IsWindows())
 #pragma warning disable CA1416 // Validate platform compatibility
         return sp.GetRequiredService<SharedMemoryService>();
 #pragma warning restore CA1416 // Validate platform compatibility
-
     });
 }
 else

--- a/R3E.YaHud/Program.cs
+++ b/R3E.YaHud/Program.cs
@@ -39,8 +39,19 @@ builder.Services.AddSingleton<ShortcutService>();
 if (OperatingSystem.IsWindows())
 {
     builder.Services.AddSingleton<SharedMemoryService>();
-    builder.Services.AddSingleton<ISharedSource>(sp => sp.GetRequiredService<SharedMemoryService>());
-    builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<SharedMemoryService>());
+    builder.Services.AddSingleton<ISharedSource>(sp =>
+    {
+#pragma warning disable CA1416 // Validate platform compatibility
+        return sp.GetRequiredService<SharedMemoryService>();
+#pragma warning restore CA1416 // Validate platform compatibility
+    });
+    builder.Services.AddSingleton<IHostedService>(sp =>
+    {
+#pragma warning disable CA1416 // Validate platform compatibility
+        return sp.GetRequiredService<SharedMemoryService>();
+#pragma warning restore CA1416 // Validate platform compatibility
+
+    });
 }
 else
 {


### PR DESCRIPTION
This pull request makes a minor update to the Windows-specific service registrations in `Program.cs`. The main change is the addition of platform compatibility warning suppressions when resolving `SharedMemoryService` for the `ISharedSource` and `IHostedService` interfaces.

* Suppressed CA1416 platform compatibility warnings in the service registrations for `ISharedSource` and `IHostedService` to ensure compatibility checks do not interfere with Windows-only logic in `Program.cs`.Wrapped SharedMemoryService registrations in lambdas with CA1416 pragma directives to suppress platform compatibility warnings when registering ISharedSource and IHostedService on Windows. Service logic remains unchanged.