### PR TITLE
Added Car damage widget

### DIFF
--- a/R3E.YaHud/Components/Pages/Index.razor
+++ b/R3E.YaHud/Components/Pages/Index.razor
@@ -62,6 +62,7 @@
     <Clock />
     <MoTec />
     <UserInputs />
+    <R3E.YaHud.Components.Widget.CarDamage.CarDamage />
     <FuelCalc />
     <StartLight />
     <RelativeDriver />

--- a/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor
+++ b/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor
@@ -1,0 +1,109 @@
+﻿@using R3E.YaHud.Components.Widget.CarDamage.Components
+@using R3E.YaHud.Components.Widget.Core
+@inherits HudWidgetBase<CarDamageSettings>
+@implements IDisposable
+
+@if (Settings?.Visible ?? false)
+{
+    <div id=@ElementId class="car-damage-widget">
+        <div class="damage-item">
+            <div class="damage-label" style="color: @EngineDamageColor">Engine</div>
+            <div class="damage-bar"><HorizontalBar Value="@EngineDamage" Min="0" Max="1" PrimaryColor="@EngineDamageColor" BackgroundColor="#333333" /></div>
+        </div>
+        <div class="damage-item">
+            <div class="damage-label" style="color: @AeroDamageColor">Aero</div>
+            <div class="damage-bar"><HorizontalBar Value="@AeroDamage" Min="0" Max="1" PrimaryColor="@AeroDamageColor" BackgroundColor="#333333" /></div>
+        </div>  
+        <div class="damage-item">
+            <div class="damage-label" style="color: @TransmissionDamageColor">Transmission</div>
+            <div class="damage-bar"><HorizontalBar Value="@TransmissionDamage" Min="0" Max="1" PrimaryColor="@TransmissionDamageColor" BackgroundColor="#333333" /></div>
+        </div>
+        <div class="damage-item">
+            <div class="damage-label" style="color: @SuspensionDamageColor">Suspension</div>
+            <div class="damage-bar"><HorizontalBar Value="@SuspensionDamage" Min="0" Max="1" PrimaryColor="@SuspensionDamageColor" BackgroundColor="#333333" /></div>
+        </div>
+    </div>
+}
+
+@code {
+
+
+    public override string ElementId { get => "carDamageWidget"; }
+    public override string Name => "Car Damage";
+    public override string Category => "Telemetry";
+
+    public override double DefaultXPercent => 20;
+    public override double DefaultYPercent => 90;
+
+    public override bool Collidable => true;
+
+    public float EngineDamage { get; set; } = 1;
+    public float AeroDamage { get; set; } = 1;
+    public float TransmissionDamage { get; set; } = 1;
+    public float SuspensionDamage { get; set; } = 1;
+
+    private string EngineDamageColor { get; set; } = "#ffffff";
+    private string AeroDamageColor { get; set; } = "#ffffff";
+    private string TransmissionDamageColor { get; set; } = "#ffffff";
+    private string SuspensionDamageColor { get; set; } = "#ffffff";
+
+    public CarDamage()
+    {
+        UpdateInterval = TimeSpan.FromMilliseconds(500);
+    }
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+    }
+
+    protected override void Update()
+    {
+        var carDamage = TelemetryService.Data.Raw.CarDamage;
+
+        EngineDamage = carDamage.Engine;
+        AeroDamage = carDamage.Aerodynamics;
+        TransmissionDamage = carDamage.Transmission;
+        SuspensionDamage = carDamage.Suspension;
+
+        EngineDamageColor = DamageColor(EngineDamage);
+        AeroDamageColor = DamageColor(AeroDamage);
+        TransmissionDamageColor = DamageColor(TransmissionDamage);
+        SuspensionDamageColor = DamageColor(SuspensionDamage);
+
+    }
+
+    private string DamageColor(float damage)
+    {
+        if(damage >= Settings!.WornThreshold)
+        {
+            return Settings!.PristineColor;
+        }else if(damage >= Settings!.DamagedThreshold)
+        {
+            return Settings!.WornColor;
+        }
+        else
+        {
+            return Settings!.DamagedColor;
+        }
+    }
+
+    protected override void UpdateWithTestData()
+    {
+        EngineDamage = 0.9f;
+        AeroDamage = 0.75f;
+        TransmissionDamage = 0.5f;
+        SuspensionDamage = 0.2f;
+
+        EngineDamageColor = DamageColor(EngineDamage);
+        AeroDamageColor = DamageColor(AeroDamage);
+        TransmissionDamageColor = DamageColor(TransmissionDamage);
+        SuspensionDamageColor = DamageColor(SuspensionDamage);
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
+    }
+
+}

--- a/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor
+++ b/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor
@@ -13,7 +13,7 @@
         <div class="damage-item">
             <div class="damage-label" style="color: @AeroDamageColor">Aero</div>
             <div class="damage-bar"><HorizontalBar Value="@AeroDamage" Min="0" Max="1" PrimaryColor="@AeroDamageColor" BackgroundColor="#333333" /></div>
-        </div>  
+        </div>
         <div class="damage-item">
             <div class="damage-label" style="color: @TransmissionDamageColor">Transmission</div>
             <div class="damage-bar"><HorizontalBar Value="@TransmissionDamage" Min="0" Max="1" PrimaryColor="@TransmissionDamageColor" BackgroundColor="#333333" /></div>
@@ -52,11 +52,6 @@
         UpdateInterval = TimeSpan.FromMilliseconds(500);
     }
 
-    protected override void OnInitialized()
-    {
-        base.OnInitialized();
-    }
-
     protected override void Update()
     {
         var carDamage = TelemetryService.Data.Raw.CarDamage;
@@ -75,10 +70,11 @@
 
     private string DamageColor(float damage)
     {
-        if(damage >= Settings!.WornThreshold)
+        if (damage >= Settings!.WornThreshold)
         {
             return Settings!.PristineColor;
-        }else if(damage >= Settings!.DamagedThreshold)
+        }
+        else if (damage >= Settings!.DamagedThreshold)
         {
             return Settings!.WornColor;
         }
@@ -99,11 +95,6 @@
         AeroDamageColor = DamageColor(AeroDamage);
         TransmissionDamageColor = DamageColor(TransmissionDamage);
         SuspensionDamageColor = DamageColor(SuspensionDamage);
-    }
-
-    public override void Dispose()
-    {
-        base.Dispose();
     }
 
 }

--- a/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor.css
+++ b/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor.css
@@ -1,0 +1,48 @@
+﻿.car-damage-widget {
+    z-index: 5000;
+    text-align: center;
+    width: 300px;
+    height: 100px;
+    position: absolute;
+    border-radius: 4px;
+    background-color: rgba(2, 0, 0, 0.5);
+    white-space: nowrap; 
+    overflow: hidden;
+    box-sizing: border-box; 
+
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly; 
+    padding: 3px; 
+}
+
+.damage-label {
+    font-size: 16px;
+    font-weight: bold;
+    margin-bottom: 2px;
+}
+
+.damage-item {
+    margin: 2px 0;
+}
+
+.damage-item {
+    display: flex;
+    align-items: center; 
+    gap: 0px 8px;
+    margin: 0; 
+}
+
+.damage-label {
+    margin-bottom: 0; 
+    width: 95px; 
+    text-align: left;
+}
+
+.damage-bar {
+    flex: 1 1 auto; 
+}
+
+.damage-bar > div {
+    width: 100%;
+}

--- a/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor.css
+++ b/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor.css
@@ -2,7 +2,7 @@
     z-index: 5000;
     text-align: center;
     width: 300px;
-    height: 100px;
+    height: 110px;
     position: absolute;
     border-radius: 4px;
     background-color: rgba(2, 0, 0, 0.5);
@@ -13,7 +13,7 @@
     display: flex;
     flex-direction: column;
     justify-content: space-evenly; 
-    padding: 3px; 
+    padding: 3px 6px 3px 6px; 
 }
 
 .damage-label {
@@ -45,4 +45,9 @@
 
 .damage-bar > div {
     width: 100%;
+}
+
+/* Make inner bar slightly shorter in height for compactness */
+.damage-bar > div > div {
+    height: 18px;
 }

--- a/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor.css
+++ b/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor.css
@@ -20,23 +20,16 @@
     font-size: 16px;
     font-weight: bold;
     margin-bottom: 2px;
+    width: 95px; 
+    text-align: left;
 }
 
 .damage-item {
     margin: 2px 0;
-}
-
-.damage-item {
     display: flex;
     align-items: center; 
     gap: 0px 8px;
     margin: 0; 
-}
-
-.damage-label {
-    margin-bottom: 0; 
-    width: 95px; 
-    text-align: left;
 }
 
 .damage-bar {

--- a/R3E.YaHud/Components/Widget/CarDamage/CarDamageSettings.cs
+++ b/R3E.YaHud/Components/Widget/CarDamage/CarDamageSettings.cs
@@ -36,6 +36,6 @@ namespace R3E.YaHud.Components.Widget.CarDamage
             Description = "The color of the bar when the car is in damaged state.",
             ViewMode = SettingsViewMode.Expert)]
 
-        public string DamagedColor { get; set; } = "#ffff0000";
+        public string DamagedColor { get; set; } = "#ff0000";
     }
 }

--- a/R3E.YaHud/Components/Widget/CarDamage/CarDamageSettings.cs
+++ b/R3E.YaHud/Components/Widget/CarDamage/CarDamageSettings.cs
@@ -1,0 +1,41 @@
+﻿using R3E.YaHud.Components.Widget.Core;
+using R3E.YaHud.Services.Settings;
+
+namespace R3E.YaHud.Components.Widget.CarDamage
+{
+    public class CarDamageSettings : BasicSettings
+    {
+
+        [SettingType("Pristine Color", SettingsTypes.ColorPicker, 10,
+            Description = "The color of the bar when the car is in pristine state.",
+            ViewMode = SettingsViewMode.Expert)]
+        public string PristineColor { get; set; } = "#ffffff";
+
+        [SettingType("Worn Threshold", SettingsTypes.Slider, 10,
+            Description = "The threshold at which the car is considered worn.",
+            Max = 1.0f,
+            Min = 0.0f,
+            Step = 0.01f,
+            ViewMode = SettingsViewMode.Intermediate)]
+        public float WornThreshold { get; set; } = 0.75f;
+
+        [SettingType("Worn Color", SettingsTypes.ColorPicker, 10,
+            Description = "The color of the bar when the car is in worn state.",
+            ViewMode = SettingsViewMode.Expert)]
+        public string WornColor { get; set; } = "#ffff00";
+
+        [SettingType("Damaged Threshold", SettingsTypes.Slider, 10,
+            Description = "The threshold at which the car is considered damaged.",
+            Max = 1.0f,
+            Min = 0.0f,
+            Step = 0.01f,
+            ViewMode = SettingsViewMode.Intermediate)]
+        public float DamagedThreshold { get; set; } = 0.35f;
+
+        [SettingType("Damaged Color", SettingsTypes.ColorPicker, 10,
+            Description = "The color of the bar when the car is in damaged state.",
+            ViewMode = SettingsViewMode.Expert)]
+
+        public string DamagedColor { get; set; } = "#ffff0000";
+    }
+}

--- a/R3E.YaHud/Components/Widget/CarDamage/Components/HorizontalBar.razor
+++ b/R3E.YaHud/Components/Widget/CarDamage/Components/HorizontalBar.razor
@@ -1,5 +1,5 @@
 ﻿<div>
-    <div style="width: 95%; background-color: @BackgroundColor; border-radius: 4px; overflow: hidden;">
+    <div style="width: 100%; background-color: @BackgroundColor; border-radius: 4px; overflow: hidden;">
         <div style="
                     width:@Percent;
                     background-color:@PrimaryColor;

--- a/R3E.YaHud/Components/Widget/CarDamage/Components/HorizontalBar.razor
+++ b/R3E.YaHud/Components/Widget/CarDamage/Components/HorizontalBar.razor
@@ -1,0 +1,25 @@
+﻿<div>
+    <div style="width: 95%; background-color: @BackgroundColor; border-radius: 4px; overflow: hidden;">
+        <div style="
+                    width:@Percent;
+                    background-color:@PrimaryColor;
+                    height:16px;">
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public double Min { get; set; } = 0;
+    [Parameter] public double Max { get; set; } = 100;
+    [Parameter] public double Value { get; set; }
+    [Parameter] public string PrimaryColor { get; set; } = "white";
+    [Parameter] public string BackgroundColor { get; set; } = "darkgray";
+
+    string Percent =>
+        Max == Min
+            ? "0%"
+            : (Math.Clamp((Value - Min) / (Max - Min) * 100.0, 0.0, 100.0)
+                .ToString("0.##")
+                .Replace(",", ".") + "%");
+
+}


### PR DESCRIPTION
This pull request introduces a new "Car Damage" widget to the HUD, allowing users to visualize the current state of their car's engine, aerodynamics, transmission, and suspension damage in real time. The widget is configurable, supports color-coded thresholds, and is styled for compact display.

**New Car Damage Widget Feature:**

* Added the `CarDamage` widget component (`CarDamage.razor`) which displays four damage bars (engine, aero, transmission, suspension) with dynamic colors based on damage thresholds. The widget updates periodically using telemetry data.
* Created a settings class `CarDamageSettings` to allow customization of damage thresholds and bar colors for pristine, worn, and damaged states.

**UI and Styling:**

* Implemented a reusable `HorizontalBar` component for rendering the damage bars visually.
* Added specific CSS styles for the car damage widget to ensure a clear and compact layout within the HUD.

**Integration:**

* Integrated the new `CarDamage` widget into the main HUD page by adding it to `Index.razor`, making it visible alongside other widgets.