### PR TITLE
Handle JS interop cancellation/disconnect in SettingsService

### DIFF
--- a/R3E.YaHud/Services/Settings/SettingsService.cs
+++ b/R3E.YaHud/Services/Settings/SettingsService.cs
@@ -59,6 +59,16 @@ namespace R3E.YaHud.Services.Settings
             {
                 // Ignore during server-side prerendering
             }
+            catch (TaskCanceledException)
+            {
+                // Ignore when JavaScript runtime is no longer available (e.g., during shutdown or navigation)
+                logger.LogDebug("JS interop cancelled for {Id} - likely during shutdown in {Location}", id, nameof(Save));
+            }
+            catch (JSDisconnectedException)
+            {
+                // Ignore when JavaScript connection has been disconnected
+                logger.LogDebug("JS disconnected for {Id} in {Location}", id, nameof(Save));
+            }
         }
 
         public async Task SaveAll()
@@ -85,6 +95,18 @@ namespace R3E.YaHud.Services.Settings
                     when (ex.Message.Contains("server-side static rendering"))
             {
                 // Ignore during server-side prerendering
+                return null;
+            }
+            catch (TaskCanceledException)
+            {
+                // Ignore when JavaScript runtime is no longer available
+                logger.LogDebug("JS interop cancelled for {Id} - likely during shutdown in {Location}", id, nameof(Load));
+                return null;
+            }
+            catch (JSDisconnectedException)
+            {
+                // Ignore when JavaScript connection has been disconnected
+                logger.LogDebug("JS disconnected for {Id} in {Location}", id, nameof(Load));
                 return null;
             }
         }
@@ -122,6 +144,16 @@ namespace R3E.YaHud.Services.Settings
                     when (ex.Message.Contains("server-side static rendering"))
             {
                 // Ignore during server-side prerendering
+            }
+            catch (TaskCanceledException)
+            {
+                // Ignore when JavaScript runtime is no longer available
+                logger.LogDebug("JS interop cancelled for {Id} - likely during shutdown in {Location}", id, nameof(Clear));
+            }
+            catch (JSDisconnectedException)
+            {
+                // Ignore when JavaScript connection has been disconnected
+                logger.LogDebug("JS disconnected for {Id} in {Location}", id, nameof(Clear));
             }
         }
     }


### PR DESCRIPTION
This pull request improves the robustness of the `SettingsService` by adding better exception handling for JavaScript interop operations. It specifically ensures that scenarios like application shutdown or JavaScript disconnection are handled gracefully, with appropriate debug logging for easier troubleshooting.

**Exception handling improvements:**

* Added handling for `TaskCanceledException` and `JSDisconnectedException` in the `Save`, `SaveAll`, and `Clear` methods of `SettingsService.cs`, preventing errors during shutdown or navigation and logging debug messages for these cases. [[1]](diffhunk://#diff-17c188f7bbf87a2de98ba429022c7695bdb36245c5c8eab0c5fb738c20d42de9R62-R71) [[2]](diffhunk://#diff-17c188f7bbf87a2de98ba429022c7695bdb36245c5c8eab0c5fb738c20d42de9R100-R111) [[3]](diffhunk://#diff-17c188f7bbf87a2de98ba429022c7695bdb36245c5c8eab0c5fb738c20d42de9R148-R157)Add exception handling for TaskCanceledException and JSDisconnectedException in Save, Load, and Clear methods. Log debug messages when JS interop is cancelled or disconnected, preventing errors during shutdown or navigation and improving robustness.