### PR TITLE
Fix radar width calculation

### DIFF
--- a/R3E.YaHud/Components/Widget/Radar/Radar.razor
+++ b/R3E.YaHud/Components/Widget/Radar/Radar.razor
@@ -134,8 +134,8 @@
         // set alert cooldown from settings
         alertCooldown = TimeSpan.FromMilliseconds(Settings.BeepingInterval);
 
-        // if radar hasn't been measured yet, skip visual layout
-        if (radarWidth <= 0) return;
+        // // if radar hasn't been measured yet, skip visual layout
+        // if (radarWidth <= 0) return;
 
         // snapshot for rendering
         var snapshot = radarModel.DriverStates ?? new Dictionary<int, RadarDriverSnapshot>();


### PR DESCRIPTION
Quick fix as something has broken the radar width calculation currently always is 0 making it return prematurely.