### PR TITLE
Refactor HUD widget rendering with WidgetHost

### DIFF
--- a/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor
+++ b/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor
@@ -3,9 +3,8 @@
 @inherits HudWidgetBase<CarDamageSettings>
 @implements IDisposable
 
-@if (Settings?.Visible ?? false)
-{
-    <div id=@ElementId class="car-damage-widget">
+<WidgetHost Owner="this">
+    <div class="car-damage-widget">
         <div class="damage-item">
             <div class="damage-label" style="color: @EngineDamageColor">Engine</div>
             <div class="damage-bar"><HorizontalBar Value="@EngineDamage" Min="0" Max="1" PrimaryColor="@EngineDamageColor" BackgroundColor="#333333" /></div>
@@ -23,7 +22,7 @@
             <div class="damage-bar"><HorizontalBar Value="@SuspensionDamage" Min="0" Max="1" PrimaryColor="@SuspensionDamageColor" BackgroundColor="#333333" /></div>
         </div>
     </div>
-}
+</WidgetHost>
 
 @code {
 

--- a/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor.css
+++ b/R3E.YaHud/Components/Widget/CarDamage/CarDamage.razor.css
@@ -3,7 +3,6 @@
     text-align: center;
     width: 300px;
     height: 110px;
-    position: absolute;
     border-radius: 4px;
     background-color: rgba(2, 0, 0, 0.5);
     white-space: nowrap; 

--- a/R3E.YaHud/Components/Widget/Clock/Clock.razor
+++ b/R3E.YaHud/Components/Widget/Clock/Clock.razor
@@ -21,11 +21,8 @@
     public override double DefaultYPercent => 20;
 
     public override bool Collidable => false;
+    protected override bool UseR3EData => false;
 
-    public Clock()
-    {
-        UseR3EData = false;
-    }
 
     protected override void OnInitialized()
     {

--- a/R3E.YaHud/Components/Widget/Clock/Clock.razor
+++ b/R3E.YaHud/Components/Widget/Clock/Clock.razor
@@ -2,12 +2,11 @@
 @inherits HudWidgetBase<ClockSettings>
 @implements IDisposable
 
-@if (Settings?.Visible ?? false)
-{
-    <div id=@ElementId class="clock-widget">
+<WidgetHost Owner="this">
+    <div class="clock-widget">
         <span class="text" style="color: @Settings.TextColor">@currentTime.ToString("HH:mm:ss")</span>
     </div>
-}
+</WidgetHost>
 
 @code {
     private DateTime currentTime = DateTime.Now;

--- a/R3E.YaHud/Components/Widget/Clock/Clock.razor.css
+++ b/R3E.YaHud/Components/Widget/Clock/Clock.razor.css
@@ -2,7 +2,6 @@
     z-index: 5000;
     text-align: center;
     width: 300px;
-    position: absolute;
     white-space: nowrap; /* Prevent text wrapping */
     overflow: hidden; /* Prevent scrollbars inside the widget */
     box-sizing: border-box; /* Include padding/border in width */

--- a/R3E.YaHud/Components/Widget/Core/HudWidgetBase.cs
+++ b/R3E.YaHud/Components/Widget/Core/HudWidgetBase.cs
@@ -36,7 +36,7 @@ namespace R3E.YaHud.Components.Widget.Core
         public TSettings? Settings { get; set; }
         public Type GetSettingsType() => typeof(TSettings);
 
-        protected bool UseR3EData { get; set; } = true;
+        protected virtual bool UseR3EData { get; set; } = true;
         protected TimeSpan UpdateInterval { get; set; } = TimeSpan.FromMilliseconds(100);
 
         private DateTime lastUpdate = DateTime.MinValue;

--- a/R3E.YaHud/Components/Widget/Core/HudWidgetBase.cs
+++ b/R3E.YaHud/Components/Widget/Core/HudWidgetBase.cs
@@ -25,7 +25,6 @@ namespace R3E.YaHud.Components.Widget.Core
         public abstract string Name { get; }
         public abstract string Category { get; }
 
-        private bool visibleInitialized = false;
 
         public abstract double DefaultXPercent { get; }
         public abstract double DefaultYPercent { get; }
@@ -99,13 +98,6 @@ namespace R3E.YaHud.Components.Widget.Core
 
         private void Settings_PropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == nameof(BasicSettings.Visible))
-            {
-                if (Settings?.Visible ?? false)
-                {
-                    visibleInitialized = false;
-                }
-            }
             InvokeAsync(StateHasChanged);
         }
 
@@ -185,7 +177,6 @@ namespace R3E.YaHud.Components.Widget.Core
 
             Settings = new TSettings() { XPercent = DefaultXPercent, YPercent = DefaultYPercent };
             Settings.PropertyChanged += Settings_PropertyChanged;
-            visibleInitialized = false;
 
             await SettingsService.Clear(this);
             await InvokeAsync(StateHasChanged);

--- a/R3E.YaHud/Components/Widget/Core/WidgetHost.razor
+++ b/R3E.YaHud/Components/Widget/Core/WidgetHost.razor
@@ -1,0 +1,48 @@
+﻿@inject R3E.YaHud.Services.VisibilityService VisibilityService
+@implements IDisposable
+
+@if (IsVisible)
+{
+    @if (Owner == null)
+    {
+        <div class="widget-host" style="display:none">
+            @ChildContent
+        </div>
+    }
+    else
+    {
+        <div id="@OwnerElementId"
+             class="widget-host @CssClass"
+             style="transform: scale(1); transform-origin: center center;">
+            @ChildContent
+        </div>
+    }
+}
+
+
+@code {
+    [Parameter] public IWidget? Owner { get; set; }
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+    [Parameter] public string CssClass { get; set; } = string.Empty;
+
+    private string OwnerElementId => Owner switch
+    {
+        null => string.Empty,
+        _ => Owner.ElementId // IWidget should expose ElementId; use direct interface property if available
+    };
+
+    private bool IsVisible => Owner?.Settings?.Visible ?? false;
+
+
+    protected override void OnInitialized()
+    {
+        VisibilityService.OnVisibilityChanged += OnGlobalVisibilityChanged;
+    }
+
+    private void OnGlobalVisibilityChanged(bool _) => InvokeAsync(StateHasChanged);
+
+    public void Dispose()
+    {
+        VisibilityService.OnVisibilityChanged -= OnGlobalVisibilityChanged;
+    }
+}

--- a/R3E.YaHud/Components/Widget/Core/WidgetHost.razor.css
+++ b/R3E.YaHud/Components/Widget/Core/WidgetHost.razor.css
@@ -1,0 +1,7 @@
+﻿.widget-host {
+    position: absolute;
+    display: block;
+    transform-origin: center center;
+    pointer-events: auto;
+    box-sizing: border-box;
+}

--- a/R3E.YaHud/Components/Widget/FuelCalc/FuelCalc.razor
+++ b/R3E.YaHud/Components/Widget/FuelCalc/FuelCalc.razor
@@ -3,9 +3,8 @@
 @inherits HudWidgetBase<FuelSettings>
 @inject FuelService FuelService
 
-@if (Settings?.Visible ?? false)
-{
-    <div id=@ElementId class="Fuel-widget">
+<WidgetHost Owner="this">
+    <div class="Fuel-widget">
         <div class="data-grid">
             <div class="data-box large-box">
                 <p class="value" style="color: @FuelRemainingColor">@(FuelRemaining.ToString("F1"))</p>
@@ -43,7 +42,7 @@
             </div>
         </div>
     </div>
-}
+</WidgetHost>
 
 @code {
     /// <summary>

--- a/R3E.YaHud/Components/Widget/FuelCalc/FuelCalc.razor.css
+++ b/R3E.YaHud/Components/Widget/FuelCalc/FuelCalc.razor.css
@@ -1,7 +1,6 @@
 ﻿.Fuel-widget {
     display: flex;
     align-items: center;
-    position: absolute;
 
     height: auto;        /* <-- key change */
     min-height: 10vmin;  /* keeps it visually consistent */

--- a/R3E.YaHud/Components/Widget/FuelGauge/FuelGauge.razor
+++ b/R3E.YaHud/Components/Widget/FuelGauge/FuelGauge.razor
@@ -3,9 +3,8 @@
 @inherits HudWidgetBase<FuelGaugeSettings>
 @implements IDisposable
 
-@if (Settings?.Visible ?? false)
-{
-    <div id=@ElementId class="fuel-gauge-widget">
+<WidgetHost Owner="this">
+    <div class="fuel-gauge-widget">
         <div class="fuel-component">
             <VerticalBar @key="FuelLevel"
                          Min="0.0d"
@@ -19,7 +18,7 @@
             <R3E.YaHud.Components.UI.Components.Icon Name="gas-pump" />
         </svg>
     </div>
-}
+</WidgetHost>
 
 @code {
 

--- a/R3E.YaHud/Components/Widget/FuelGauge/FuelGauge.razor.css
+++ b/R3E.YaHud/Components/Widget/FuelGauge/FuelGauge.razor.css
@@ -7,7 +7,6 @@
     text-align: center;
     width: 36px;
     height: 175px;
-    position: absolute;
     border-radius: 4px;
     background-color: rgba(2, 0, 0, 0.5);
     white-space: nowrap;

--- a/R3E.YaHud/Components/Widget/LapProgress/LapProgress.razor
+++ b/R3E.YaHud/Components/Widget/LapProgress/LapProgress.razor
@@ -7,9 +7,8 @@
 @implements IDisposable
 @inject SectorService SectorService
 
-@if (Settings?.Visible ?? false)
-{
-    <div id=@ElementId>
+<WidgetHost Owner="this">
+    <div id="layout">
         <span id="time-delta-best-lap" style="color: @TimeDeltaBestLapSelfColor;">@GetTimeFormatted(TimeDeltaBestLapSelf, -1000)</span>
     
         <div id="box-container">
@@ -35,7 +34,7 @@
             <span id="estimate-position" style="color: @Settings.SectorTimeAndInfoTextColor; display: @(IsQualifying ? "block" : "none");">Est. Pos: @(EstimatedPosition != -1 ? EstimatedPosition : "-")</span>
         </div>
     </div>
-}
+</WidgetHost>
 
 
 @code {

--- a/R3E.YaHud/Components/Widget/LapProgress/LapProgress.razor
+++ b/R3E.YaHud/Components/Widget/LapProgress/LapProgress.razor
@@ -8,7 +8,7 @@
 @inject SectorService SectorService
 
 <WidgetHost Owner="this">
-    <div id="layout">
+    <div id="lap-progress-layout">
         <span id="time-delta-best-lap" style="color: @TimeDeltaBestLapSelfColor;">@GetTimeFormatted(TimeDeltaBestLapSelf, -1000)</span>
     
         <div id="box-container">

--- a/R3E.YaHud/Components/Widget/LapProgress/LapProgress.razor.css
+++ b/R3E.YaHud/Components/Widget/LapProgress/LapProgress.razor.css
@@ -1,4 +1,4 @@
-﻿#layout {
+﻿#lap-progress-layout {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/R3E.YaHud/Components/Widget/LapProgress/LapProgress.razor.css
+++ b/R3E.YaHud/Components/Widget/LapProgress/LapProgress.razor.css
@@ -1,4 +1,4 @@
-﻿#progressWidget {
+﻿#layout {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/R3E.YaHud/Components/Widget/MoTec/MoTec.razor
+++ b/R3E.YaHud/Components/Widget/MoTec/MoTec.razor
@@ -3,9 +3,8 @@
 @using R3E.YaHud.Components.Widget.MoTec.Components
 @inherits HudWidgetBase<MoTecSettings>
 
-@if (Settings?.Visible ?? false)
-{
-    <div id=@ElementId class="motec-widget text">
+<WidgetHost Owner="this">
+    <div class="motec-widget text">
         <p class="gear-text" style="color:@RpsCurrentColor">@Gear</p>
         <p class="speed-text" style="color:@RpsCurrentColor">@Speed.ToString("0")</p>
         <div class="rpm-component">
@@ -17,7 +16,7 @@
                            BackgroundColor="@RpsBarBackgroundColor" />
         </div>
     </div>
-}
+</WidgetHost>
 
 @code {
     private string Gear { get; set; } = "N";

--- a/R3E.YaHud/Components/Widget/MoTec/MoTec.razor.css
+++ b/R3E.YaHud/Components/Widget/MoTec/MoTec.razor.css
@@ -7,7 +7,6 @@
     width: 150px; /* fixed width */
     height: 175px; /* fixed height */
     background-color: rgba(2, 0, 0, 0.5);
-    position: absolute; /* can still be placed absolutely */
     box-sizing: border-box;
     overflow: hidden;
     padding: 5px;

--- a/R3E.YaHud/Components/Widget/Radar/Radar.razor
+++ b/R3E.YaHud/Components/Widget/Radar/Radar.razor
@@ -8,9 +8,8 @@
 @inherits HudWidgetBase<RadarSettings>
 @inject RadarService RadarService
 
-@if (Settings?.Visible ?? false)
-{
-    <div id=@ElementId class="radar-widget">
+<WidgetHost Owner="this">
+    <div class="radar-widget">
         <div id="radar" @ref="radarElement" style="@RadarStyling.ToString()">
             @foreach (var child in activeDriverSlots)
             {
@@ -20,8 +19,7 @@
             }
         </div>
     </div>
-}
-
+</WidgetHost>
 
 @code {
 

--- a/R3E.YaHud/Components/Widget/Radar/Radar.razor.css
+++ b/R3E.YaHud/Components/Widget/Radar/Radar.razor.css
@@ -7,7 +7,6 @@
     width: 210px; /* fixed width */
     height: 210px; /* fixed height */
     /*background-color: rgba(2, 0, 0, 0.5);*/
-    position: absolute; /* can still be placed absolutely */
     box-sizing: border-box;
     overflow: hidden;
     padding: 5px;

--- a/R3E.YaHud/Components/Widget/RelativeDriver/RelativeDriver.razor
+++ b/R3E.YaHud/Components/Widget/RelativeDriver/RelativeDriver.razor
@@ -10,9 +10,8 @@
 @inject ITimeGapService TimeGapService
 @inject DriverService DriverService
 
-@if (Settings?.Visible ?? false)
-{
-    <div id=@ElementId class="relative-driver-widget">
+<WidgetHost Owner="this">
+    <div class="relative-driver-widget">
         @if (displayDrivers.Count > 0)
         {
             <div class="driver-table">
@@ -61,7 +60,7 @@
             </div>
         }
     </div>
-}
+</WidgetHost>
 
 @code {
     public override string ElementId { get => "relativeDriverWidget"; }

--- a/R3E.YaHud/Components/Widget/RelativeDriver/RelativeDriver.razor.css
+++ b/R3E.YaHud/Components/Widget/RelativeDriver/RelativeDriver.razor.css
@@ -3,7 +3,6 @@
     border-radius: 4px;
     width: 400px;
     height: 175px;
-    position: absolute;
     box-sizing: border-box;
     overflow: hidden;
     padding: 5px;

--- a/R3E.YaHud/Components/Widget/StartLight/StartLight.razor
+++ b/R3E.YaHud/Components/Widget/StartLight/StartLight.razor
@@ -1,10 +1,9 @@
 ﻿@using R3E.YaHud.Components.Widget.Core
 @inherits HudWidgetBase<StartLightSettings>
 
-@if (Settings?.Visible ?? false)
-{
+<WidgetHost Owner="this">
     <div style="visibility: @(IsCountdownPhase || TestMode ? "visible" : "hidden");">
-        <div id=@ElementId class="start-light-widget text">
+        <div class="start-light-widget text">
             <div class="lights-and-glows-container">
                 <div class="lights-container">
                     @for (int i = 1; i <= 5; i++)
@@ -27,7 +26,7 @@
             </div>
         </div>
     </div>
-}
+</WidgetHost>
 
 @code {
 

--- a/R3E.YaHud/Components/Widget/StartLight/StartLight.razor.css
+++ b/R3E.YaHud/Components/Widget/StartLight/StartLight.razor.css
@@ -10,7 +10,6 @@
     /* subtle vertical gradient from gray to black */
     background: linear-gradient(180deg, #3a3a3a 0%, #2a2a2a 50%, #000000 100%);
     border: 1px solid rgba(255,255,255,0.03);
-    position: absolute;
     box-sizing: border-box;
     overflow: visible;
     user-select: none; /* prevent text selection */

--- a/R3E.YaHud/Components/Widget/UserInputs/UserInputs.razor
+++ b/R3E.YaHud/Components/Widget/UserInputs/UserInputs.razor
@@ -2,9 +2,8 @@
 @using R3E.YaHud.Components.Widget.UserInputs.Components
 @inherits HudWidgetBase<UserInputsSettings>
 
-@if (Settings?.Visible ?? false)
-{
-    <div id=@ElementId class="user-inputs-widget text">
+<WidgetHost Owner="this">
+    <div class="user-inputs-widget text">
         <div class="pedals-container">
             @if (Settings.ShowClutch)
             {
@@ -70,7 +69,7 @@
             </div>
         }
     </div>
-}
+</WidgetHost>
 
 @code {
     private double ClutchRaw { get; set; } = 0.0d;

--- a/R3E.YaHud/Components/Widget/UserInputs/UserInputs.razor.css
+++ b/R3E.YaHud/Components/Widget/UserInputs/UserInputs.razor.css
@@ -9,7 +9,6 @@
     width: 80px;
     height: 175px;
     background-color: rgba(2, 0, 0, 0.5);
-    position: absolute;
     box-sizing: border-box;
     overflow: hidden;
     padding: 4px;

--- a/R3E.YaHud/wwwroot/js/HudHelper.js
+++ b/R3E.YaHud/wwwroot/js/HudHelper.js
@@ -69,7 +69,6 @@ window.HudHelper = (function () {
             // skip non-collidable others
             if (!other.collidable) continue;
             const otherRectDom = getEntryRect(other);
-            console.log(proposedRect, otherRectDom);
             // skip if not visible or zero-sized
             if (otherRectDom.width === 0 || otherRectDom.height === 0) continue;
             if (rectsIntersect(proposedRect, otherRectDom)) return true;

--- a/R3E.YaHud/wwwroot/js/HudHelper.js
+++ b/R3E.YaHud/wwwroot/js/HudHelper.js
@@ -44,7 +44,10 @@ window.HudHelper = (function () {
 
     function getEntryRectAt(entry, left, top) {
         const el = entry.el;
-        return { left: left, top: top, width: el.offsetWidth, height: el.offsetHeight };
+        const rect = el.getBoundingClientRect();
+        const widgetWidth = rect.width;
+        const widgetHeight = rect.height;
+        return { left: left, top: top, width: widgetWidth, height: widgetHeight };
     }
 
     function getEntryRect(entry) {
@@ -66,6 +69,7 @@ window.HudHelper = (function () {
             // skip non-collidable others
             if (!other.collidable) continue;
             const otherRectDom = getEntryRect(other);
+            console.log(proposedRect, otherRectDom);
             // skip if not visible or zero-sized
             if (otherRectDom.width === 0 || otherRectDom.height === 0) continue;
             if (rectsIntersect(proposedRect, otherRectDom)) return true;
@@ -185,8 +189,11 @@ window.HudHelper = (function () {
             const proposedY = e.clientY - entry.offsetY;
 
             // clamp to window boundaries
-            const maxX = window.innerWidth - el.offsetWidth;
-            const maxY = window.innerHeight - el.offsetHeight;
+            const rect = el.getBoundingClientRect();
+            const widgetWidth = rect.width;
+            const widgetHeight = rect.height;
+            const maxX = window.innerWidth - widgetWidth;
+            const maxY = window.innerHeight - widgetHeight;
             const clampedX = Math.max(0, Math.min(maxX, proposedX));
             const clampedY = Math.max(0, Math.min(maxY, proposedY));
 
@@ -239,8 +246,11 @@ window.HudHelper = (function () {
             // apply target position
             if (entry.isDragging) {
                 el.style.position = 'absolute';
-                el.style.left = Math.max(0, Math.min(window.innerWidth - el.offsetWidth, entry.targetX)) + 'px';
-                el.style.top = Math.max(0, Math.min(window.innerHeight - el.offsetHeight, entry.targetY)) + 'px';
+                const rect = el.getBoundingClientRect();
+                const widgetWidth = rect.width;
+                const widgetHeight = rect.height;
+                el.style.left = Math.max(0, Math.min(window.innerWidth - widgetWidth, entry.targetX)) + 'px';
+                el.style.top = Math.max(0, Math.min(window.innerHeight - widgetHeight, entry.targetY)) + 'px';
                 entry.raf = requestAnimationFrame(step);
             } else {
                 if (entry.raf) {
@@ -340,8 +350,9 @@ window.HudHelper = (function () {
                     console.warn('HudHelper.setPosition: element not found', elementId);
                     return;
                 }
-                const widgetWidth = el.offsetWidth;
-                const widgetHeight = el.offsetHeight;
+                const rect = el.getBoundingClientRect();
+                const widgetWidth = rect.width;
+                const widgetHeight = rect.height;
                 el.style.position = "absolute";
                 el.style.left = (xPercent / 100 * window.innerWidth) - (widgetWidth / 2) + "px";
                 el.style.top = (yPercent / 100 * window.innerHeight) - (widgetHeight / 2) + "px";
@@ -364,8 +375,9 @@ window.HudHelper = (function () {
                     console.warn('HudHelper.resetPosition: localStorage error', e);
                 }
 
-                const widgetWidth = el.offsetWidth;
-                const widgetHeight = el.offsetHeight;
+                const rect = el.getBoundingClientRect();
+                const widgetWidth = rect.width;
+                const widgetHeight = rect.height;
                 el.style.position = "absolute";
                 el.style.left = (xPercent / 100 * window.innerWidth) - (widgetWidth / 2) + "px";
                 el.style.top = (yPercent / 100 * window.innerHeight) - (widgetHeight / 2) + "px";

--- a/README.md
+++ b/README.md
@@ -230,16 +230,53 @@ Widgets inherit from `HudWidgetBase<TSettings>` and implement:
 Example:
 
 ```csharp
-public class MyWidget : HudWidgetBase<MyWidgetSettings>
-{
-    public override string ElementId => "myWidget";
-    public override string Name => "My Widget";
-    public override string Category => "Custom";
-    
+@using R3E.YaHud.Components.Widget.Core
+@inherits HudWidgetBase<ExampleSettings>
+@implements IDisposable
+
+<WidgetHost Owner="this">
+    <div class="example-widget">
+        <p>Widget Content</p>
+    </div>
+</WidgetHost>
+
+@code {
+    public override string ElementId { get => "exampleWidget"; }
+    public override string Name => "Example";
+    public override string Category => "ExampleCategory";
+
+    // Default placement on screen in %
+    public override double DefaultXPercent => 50;
+    public override double DefaultYPercent => 20;
+
+    //Optional
+    public override bool Collidable => false;
+    protected override bool UseR3EData => false;
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        // OBS. Can't use settings here
+    }
+
+    protected override Task OnSettingsLoadedAsync()
+    {
+        // Read default settings here into widget
+    }
+
     protected override void Update()
     {
-        // Access telemetry data via TelemetryService.Data.Raw
-        // Update widget state
+        // Access data using injected services
+    }
+
+    protected override void UpdateWithTestData()
+    {
+        // Update with test values to display state of widget
+    }
+
+    public override void Dispose()
+    {
+        base.Dispose();
     }
 }
 ```


### PR DESCRIPTION
Introduce WidgetHost component to centralize visibility and positioning for HUD widgets. Remove per-widget visibility checks and absolute positioning from individual widget components and CSS. Update HudHelper.js to use getBoundingClientRect for accurate sizing and collision detection. Clean up unused logic in HudWidgetBase.  Improves modularity, maintainability, and widget placement accuracy.

#70 