### PR TITLE
ci: group auto-generated release notes by PR label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,49 @@
+# Groups auto-generated release notes by PR label.
+# Consumed by the generateReleaseNotes call in .github/workflows/create-release.yml.
+#
+# Categories are matched top to bottom and the FIRST match wins, so a PR labelled
+# both `documentation` and `packaging` lands under Documentation. Order accordingly.
+# Any PR whose labels match nothing falls through to the `*` catch-all.
+changelog:
+  exclude:
+    labels:
+      # The develop -> main release PR would otherwise duplicate every entry.
+      - release
+      - duplicate
+      - wontfix
+      - question
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+        - widget
+
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+
+    - title: 📚 Documentation
+      labels:
+        - documentation
+
+    - title: 📦 Packaging & Distribution
+      labels:
+        - packaging
+
+    - title: ♻️ Refactoring
+      labels:
+        - refactor
+
+    - title: 🧹 Maintenance
+      labels:
+        - chore
+        - ci
+
+    - title: ⬆️ Dependencies & Runtime
+      labels:
+        - dependencies
+        - .NET
+
+    - title: 🔍 Other Changes
+      labels:
+        - "*"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -635,6 +635,43 @@ gitGraph
 - **Purpose:** Create production release
 - **Produces:** GitHub release with artifacts
 
+## 🏷️ Pull Request Labels
+
+Every PR should carry at least one **type** label. Labels are not decorative —
+[`.github/release.yml`](.github/release.yml) uses them to group the
+auto-generated release notes, so an unlabelled PR ends up under *Other Changes*.
+
+### Type labels (pick one)
+
+| Label | Use for |
+|-------|---------|
+| `enhancement` | New user-facing functionality |
+| `widget` | New HUD widget, or changes to an existing one (usually with `enhancement`) |
+| `bug` | Fixing broken behaviour |
+| `documentation` | README, CONTRIBUTING, or `docs/` changes |
+| `refactor` | Restructuring working code with no behaviour change |
+| `chore` | Housekeeping: cleanup, tooling, config, dead-code removal |
+| `ci` | GitHub Actions workflows, build, or versioning setup |
+| `packaging` | Distribution: AppImage, archives, release artifacts |
+| `dependencies` | Dependency bumps (Dependabot applies this automatically) |
+| `.NET` | Runtime, SDK, or target framework upgrades |
+| `release` | The `develop` → `main` release PR (excluded from release notes) |
+
+`chore` vs `refactor`: if you moved or rewrote production code, it's `refactor`;
+if you deleted something unused or touched only tooling and config, it's `chore`.
+
+### Platform labels (add when relevant)
+
+`linux` and `windows` mark changes that only affect one platform — for example
+the D-Bus tray code or the WinForms `NotifyIcon`. Add them alongside a type
+label, never instead of one.
+
+### Ordering caveat
+
+Release-note categories are matched top to bottom and **the first match wins**.
+A PR labelled both `documentation` and `packaging` appears under Documentation.
+If you add or reorder labels, update `.github/release.yml` to match.
+
 ## 📝 Commit Message Guidelines
 
 While not enforced, we recommend clear commit messages:


### PR DESCRIPTION
## Summary

Adds `.github/release.yml` so release notes are grouped by label, and documents the label taxonomy in `CONTRIBUTING.md`.

## Why

`create-release.yml` calls `generateReleaseNotes`. Without a `.github/release.yml`, GitHub emits a flat list of every merged PR — so **the repo's labels currently drive nothing automatically.** This makes them functional:

| Category | Labels |
|---|---|
| 🚀 Features | `enhancement`, `widget` |
| 🐛 Bug Fixes | `bug` |
| 📚 Documentation | `documentation` |
| 📦 Packaging & Distribution | `packaging` |
| ♻️ Refactoring | `refactor` |
| 🧹 Maintenance | `chore`, `ci` |
| ⬆️ Dependencies & Runtime | `dependencies`, `.NET` |
| 🔍 Other Changes | `*` |

`release` is excluded — the `develop` → `main` release PR would otherwise duplicate every entry in the notes. `duplicate`, `wontfix`, and `question` are excluded too.

## Ordering

Categories match **top to bottom, first match wins.** `documentation` is deliberately placed above `packaging` so a docs PR about packaging (like #96) lands under Documentation rather than Packaging. This is called out in both the file's header comment and CONTRIBUTING, since it's easy to break by reordering.

## CONTRIBUTING

Adds a *Pull Request Labels* section: a table of type labels with when to use each, the `chore` vs `refactor` distinction (moved/rewrote production code → `refactor`; deleted unused code or touched only tooling → `chore`), a note that `linux`/`windows` are platform modifiers that supplement rather than replace a type label, and the first-match-wins caveat.

## Verification

`.github/release.yml` parses cleanly via `js-yaml` and matches GitHub's documented schema — including `.NET` resolving to the string `".NET"` and the `"*"` wildcard surviving as the catch-all.

Effect is only observable on the next release, since `generateReleaseNotes` runs in `create-release.yml` on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)