### PR TITLE
docs: correct event bus naming and signature in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,7 @@ public class FuelService
     
     private void OnNewLap()
     {
-        eventBus.PublishFuelLevelCritical(percentage);  // Publish
+        eventBus.InvokeFuelLevelCritical(percentage);  // Raise
     }
 }
 
@@ -170,10 +170,15 @@ public class SectorService
     
     private void OnDataUpdated()
     {
-        eventBus.PublishSectorCompleted(sectorIndex);  // Publish
+        eventBus.InvokeSectorCompleted(Data, sectorIndex);  // Raise
     }
 }
 ```
+
+> **Naming convention:** the method that raises a cross-feature event is always
+> prefixed `Invoke`, matching the event name — `SectorCompleted` is raised by
+> `InvokeSectorCompleted`. `FuelLevelCritical` and `LapFuelUsageCalculated` above
+> are illustrative; `SectorCompleted` is currently the only event on the bus.
 
 ### Feature Service Pattern
 
@@ -267,13 +272,13 @@ public class FuelService : IFuelService, IDisposable
         
         oldFuelRemaining = currentFuel;
         
-        // Publish cross-feature event
-        eventBus.PublishLapFuelUsageCalculated(fuelUsed);
+        // Raise cross-feature event
+        eventBus.InvokeLapFuelUsageCalculated(fuelUsed);
         
         // Check for critical condition
         if (Data.FuelRemainingPercentage < 10.0)
         {
-            eventBus.PublishFuelLevelCritical(Data.FuelRemainingPercentage);
+            eventBus.InvokeFuelLevelCritical(Data.FuelRemainingPercentage);
         }
     }
     
@@ -325,7 +330,8 @@ Use for domain-specific communication between features:
 
 **Current Events:**
 
-- `SectorCompleted(int sectorIndex)` - Sector completed
+- `SectorCompleted(SectorData sectorData, int sectorIndex)` - Sector completed
+  (raised via `InvokeSectorCompleted(sectorData, sectorIndex)`)
 
 **Adding New Cross-Feature Events:**
 


### PR DESCRIPTION
## Summary

Fixes the two `CONTRIBUTING.md` inaccuracies that can cost a contributor real time — code examples that don't compile against the actual API. Docs only.

## 1. The mediator examples called methods that don't exist

The convention in the codebase is `Invoke*`. `ITelemetryEventBus` exposes exactly:

```csharp
event Action<SectorData, int>? SectorCompleted;
void InvokeSectorCompleted(SectorData sectorData, int sectorIndex);
```

But four call sites in the "Solution With Mediator" and Service Class Pattern examples used a `Publish*` prefix:

| Line | Was | Now |
|---|---|---|
| 160 | `eventBus.PublishFuelLevelCritical(...)` | `eventBus.InvokeFuelLevelCritical(...)` |
| 173 | `eventBus.PublishSectorCompleted(sectorIndex)` | `eventBus.InvokeSectorCompleted(Data, sectorIndex)` |
| 271 | `eventBus.PublishLapFuelUsageCalculated(...)` | `eventBus.InvokeLapFuelUsageCalculated(...)` |
| 276 | `eventBus.PublishFuelLevelCritical(...)` | `eventBus.InvokeFuelLevelCritical(...)` |

Worse, the file **contradicted itself** — the later "Adding New Cross-Feature Events" section (lines 339/350/364) already used `InvokeLapTimeImproved` correctly. Someone reading top-down learned the wrong prefix and only hit the right one further down.

Adds a short note after the example stating the `Invoke*` convention explicitly, and clarifying that `FuelLevelCritical` / `LapFuelUsageCalculated` are illustrative — `SectorCompleted` is currently the only event on the bus. That last point wasn't obvious and could send someone hunting for methods that were never there.

## 2. `SectorCompleted`'s documented signature was wrong

Listed as `SectorCompleted(int sectorIndex)`; the real event is `Action<SectorData, int>`. Wiring up a handler from the old text produces a compile error. Now documents both the signature and how it's raised.

## Scope

Deliberately limited to these two items. Still outstanding, for separate PRs:

- The **Branch Protection Rules** section (lines 569–589) describes rules that don't exist in the repo's rulesets — `main` has no PR requirement or required checks at all, and the documented check names (`validate`, `version-preview`) don't match the real job names. Needs a decision on whether to correct the doc or add the enforcement.
- All three **workflow filenames** in the GitHub Actions section are wrong (`pr-build.yml`, `pr-version-preview.yml`, `build-release.yml` don't exist).
- **Artifacts Published** omits the AppImage.
- `StartLightsChanged` is missing from the Core Events list (8 events in the interface, 7 documented).
- `bugfix/` is configured in `GitVersion.yml` but absent from the Branch Types table.

## Verification

Checked against `R3E/Core/Interfaces/ITelemetryEventBus.cs` and `ITelemetryService.cs`. No `Publish*` call sites remain; the remaining occurrences of the word "Publish" are English prose (the architecture diagram, a rules bullet, a step heading) rather than API names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)