### PR TITLE
docs: correct the GitHub Actions workflow list in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -620,20 +620,36 @@ gitGraph
 
 ## 🤖 GitHub Actions Workflows
 
-### 1. PR Build Validation (`pr-build.yml`)
-- **Triggers:** PRs to `main` or `develop`
-- **Purpose:** Validate code compiles successfully
-- **Runs:** Full solution build
+There are five workflows. Two are triggered by Git events; the other three are
+reusable and only run when called by those two.
 
-### 2. PR Version Preview (`pr-version-preview.yml`)
-- **Triggers:** PRs to `main` only
-- **Purpose:** Show what version will be released
-- **Posts:** Comment on PR with version details
+### Triggered workflows
 
-### 3. Build and Release (`build-release.yml`)
-- **Triggers:** Push to `main` (after PR merge)
-- **Purpose:** Create production release
-- **Produces:** GitHub release with artifacts
+#### PR Validation (`pr-validation.yml`)
+- **Triggers:** PRs to `main` or `develop` (opened, synchronize, reopened)
+- **Purpose:** Verify the solution compiles and preview the release version
+- **Jobs:**
+  - `Version Preview` — calls `calculate-version.yml`
+  - `Build Validation (windows-latest)` and `Build Validation (ubuntu-latest)` —
+    full solution build on both platforms. The Ubuntu leg matters: the Linux tray
+    code in `R3E.Tray/Linux` sits behind `#if LINUX` and is not compiled on
+    Windows, so a green Windows build proves nothing about it.
+  - `Post Version Comment` — posts or updates a version-preview comment on the PR
+
+#### Release (`release-on-merge.yml`)
+- **Triggers:** Push to `main` (after a PR merge), or manual `workflow_dispatch`
+- **Purpose:** Build all artifacts and create the GitHub release
+- **Jobs:** `Calculate Version` → `Build` → `Release` → `Release Summary`
+
+### Reusable workflows
+
+Invoked via `workflow_call` — these never run on their own:
+
+| Workflow | Purpose |
+|----------|---------|
+| `calculate-version.yml` | Runs GitVersion; outputs `semVer`, `fullSemVer`, `majorMinorPatch`, `branchName`, `preReleaseTag` |
+| `build-artifacts.yml` | Publishes R3E.Relay (Windows), YaHud (Windows and Linux) and the Linux AppImage, then uploads each as a workflow artifact |
+| `create-release.yml` | Creates the GitHub release, attaches every `*.zip` and `*.AppImage`, and generates the release notes |
 
 ## 📝 Commit Message Guidelines
 


### PR DESCRIPTION
## Summary

The "GitHub Actions Workflows" section listed three workflows. **None of the three filenames exist.**

| Documented | Reality |
|---|---|
| `pr-build.yml` | `pr-validation.yml` |
| `pr-version-preview.yml` | Not a workflow — the version preview is a *job* inside `pr-validation.yml` |
| `build-release.yml` | `release-on-merge.yml` |
| *(absent)* | `calculate-version.yml`, `build-artifacts.yml`, `create-release.yml` |

The trigger was wrong too: "PR Version Preview — Triggers: PRs to `main` only". `pr-validation.yml` fires on PRs to `main` **and** `develop`, and posts the version comment on both.

## What replaces it

The five workflows that actually exist, separated into the two triggered by Git events and the three reusable `workflow_call` ones. Job names are now spelled out (`Version Preview`, `Build Validation (windows-latest)`, `Build Validation (ubuntu-latest)`, `Post Version Comment`) — useful because those strings are what a required-status-check config would have to match.

Also notes why the Ubuntu build leg exists: `R3E.Tray/Linux` is behind `#if LINUX`, so a green Windows build proves nothing about the tray code. That was undocumented and is easy to "optimise away" without knowing.

## Verification

Read from the five files in `.github/workflows/`. Triggers, job names, `workflow_call` inputs/outputs and the artifact set were checked against source, not memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)