### PR TITLE
docs: describe the branch rules that actually exist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -568,25 +568,36 @@ Versions follow [Semantic Versioning 2.0.0](https://semver.org/): `MAJOR.MINOR.P
 
 ## 🛡️ Branch Protection Rules
 
+Protection is configured with **repository rulesets**, not classic branch
+protection. Neither ruleset defines bypass actors, so the rules apply to
+maintainers as well.
+
 ### Main Branch
 
-- ✅ Require pull request before merging
-- ✅ Require 1+ approvals
-- ✅ Require status checks to pass:
-  - `validate` (build validation)
-  - `version-preview` (version calculation)
-- ✅ Only allow PRs from:
-  - `develop` branch
-  - `hotfix/*` branches
-- ✅ Require branches to be up to date
+- ✅ Block branch deletion
+- ✅ Block force pushes (non-fast-forward)
 
 ### Develop Branch
 
-- ✅ Require pull request before merging
-- ✅ Require status checks to pass:
-  - `validate` (build validation)
-- ✅ Only allow PRs from:
-  - `feature/*` branches
+- ✅ Block branch deletion
+- ✅ Block force pushes (non-fast-forward)
+- ✅ Require a pull request before merging, with:
+  - 1 approving review
+  - All review conversations resolved
+  - Merge, squash and rebase all permitted
+
+### Not currently enforced
+
+The following are **not** configured, so don't rely on them:
+
+- **No required status checks on either branch.** `PR Validation` runs on every
+  PR, but a failing build does not block merging — check the result yourself
+  before merging.
+- **No PR requirement on `main`.** Direct pushes to `main` are possible, and a
+  push to `main` triggers a release build.
+- **No source-branch restrictions.** The GitFlow rules in
+  [Workflow Patterns](#-workflow-patterns) are convention, not enforcement.
+- **No linear-history or up-to-date-branch requirement.**
 
 ## GitFlow Diagram
 


### PR DESCRIPTION
## Summary

Rewrites the "Branch Protection Rules" section to match reality. **No repo settings are changed** — this documents what is configured today.

## What was wrong

The section described classic branch protection; the repo actually uses **rulesets**. Comparing bullet by bullet:

| Documented | Reality |
|---|---|
| main: require PR before merging | ❌ Not configured |
| main: require 1+ approvals | ❌ Not configured |
| main: require `validate` + `version-preview` | ❌ No required checks |
| main: only allow PRs from develop / hotfix/* | ❌ Not configured |
| main: require branches up to date | ❌ Not configured |
| develop: require PR before merging | ✅ Correct |
| develop: require `validate` | ❌ No required checks |
| develop: only allow PRs from feature/* | ❌ Not configured |
| *(undocumented)* | ⚠️ develop **does** require 1 approval + thread resolution |

All five bullets under Main were false. The check names were unusable regardless — `validate` and `version-preview` match no real job (they're `Build Validation (windows-latest)`, `Build Validation (ubuntu-latest)`, `Version Preview`).

## What replaces it

The two rulesets as configured, plus an explicit **"Not currently enforced"** list. That list is the point of the change: silently believing a required build check exists is the failure mode that costs you something. It states plainly that `PR Validation` runs but does not block merging, that `main` accepts direct pushes (which trigger a release build), and that the GitFlow source-branch rules are convention rather than enforcement.

Also notes that neither ruleset defines bypass actors, so the rules apply to maintainers too.

## Deliberately out of scope

Not adding any enforcement — no required status checks, no PR rule on `main`. If you later want the doc's original intent to be true, that's a settings change, and the required-check contexts would need to be the real job names above.

## Verification

Read from `GET /repos/SCarlsen7757/YaHud/rulesets` — `main` (id 19643672): `deletion`, `non_fast_forward`. `develop` (id 19643997): `deletion`, `non_fast_forward`, `pull_request` with `required_approving_review_count: 1` and `required_review_thread_resolution: true`. `bypass_actors` empty on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)