### PR TITLE
docs: add the AppImage to the release artifact list

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -528,24 +528,30 @@ We use **GitFlow** with automated versioning via GitVersion. All version numbers
 
 ## 📦 Release Process
 
-Releases are **fully automated** when PRs are merged to `main`.
+Releases are **built automatically** when commits land on `main`, then published
+manually — see the note on drafts below.
 
 ### What Happens on Merge to Main
 
 1. **Version Calculation** - GitVersion determines the version number
 2. **Build** - All projects are built for Windows and Linux
-3. **Package** - Creates ZIP archives of the artifacts
-4. **Release** - Creates GitHub release with:
+3. **Package** - Creates ZIP archives, plus the Linux AppImage
+4. **Release** - Creates a GitHub release with:
    - Auto-generated release notes
    - Tagged version (e.g., `v1.0.0`)
    - Build artifacts attached
+
+> **The release is created as a draft.** `release-on-merge.yml` calls
+> `create-release.yml` with `draft: true`, so the release and its tag are not
+> public until you review and publish them from the Releases page.
 
 ### Artifacts Published
 
 Each release includes:
 - `R3E.Relay-win-x64-v{version}.zip` - Windows relay service
 - `R3E.YaHud-win-x64-v{version}.zip` - Windows HUD application
-- `R3E.YaHud-linux-x64-v{version}.zip` - Linux HUD application
+- `R3E.YaHud-linux-x64-v{version}.zip` - Linux HUD application (plain binary)
+- `YaHud-v{version}-x86_64.AppImage` - Linux HUD application (AppImage, recommended)
 
 ## 🏷️ Version Numbering
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -553,6 +553,10 @@ Each release includes:
 - `R3E.YaHud-linux-x64-v{version}.zip` - Linux HUD application (plain binary)
 - `YaHud-v{version}-x86_64.AppImage` - Linux HUD application (AppImage, recommended)
 
+The AppImage is assembled by CI rather than produced by a single `dotnet publish`
+— see [How the YaHud AppImage Is Built](docs/appimage.md) for the AppDir layout,
+the pinned `appimagetool`/runtime versions and how to build one locally.
+
 ## 🏷️ Version Numbering
 
 Versions follow [Semantic Versioning 2.0.0](https://semver.org/): `MAJOR.MINOR.PATCH`


### PR DESCRIPTION
## Summary

Three corrections to the Release Process section.

**1. The AppImage was missing.** "Artifacts Published" listed three of the four artifacts a release actually carries. `YaHud-v{version}-x86_64.AppImage` has shipped since #78 and is the recommended Linux download per the README, but it was never added here. The **Package** step also said only "Creates ZIP archives of the artifacts". Also labels the plain Linux zip as such, so the two Linux options are distinguishable.

**2. Releases are drafts.** Found while verifying the above. The section opened with "Releases are **fully automated** when PRs are merged to `main`", but `release-on-merge.yml` calls `create-release.yml` with `draft: true`, and that flows through to `softprops/action-gh-release`. So the build and artifact upload are automatic, but the release and its tag stay invisible until published by hand from the Releases page.

That's worth stating plainly — waiting for a release that is actually sitting in drafts is a confusing thing to debug, and someone could reasonably conclude the pipeline broke.

**3. Cross-links the AppImage doc.** Points at [`docs/appimage.md`](docs/appimage.md) for the AppDir layout, the pinned `appimagetool`/runtime versions and local builds, and notes that the AppImage is assembled by CI rather than by a single `dotnet publish` — which is otherwise a surprise, since every other artifact in the list is one publish command.

## Merge ordering

`docs/appimage.md` is added by **#96**, so **this PR should merge alongside it.** The link was deliberately omitted when this branch was first pushed, to avoid a dead link if this merged first; that constraint has since been accepted deliberately (the README tree in #105 does the same thing).

Verified by merging all nine in-flight doc branches into a scratch branch: no conflicts, `docs/appimage.md` present, and the link targets in both `CONTRIBUTING.md` and `README.md` resolve.

## Verification

Artifact names cross-checked against the four upload steps in `build-artifacts.yml` and the `files:` globs in `create-release.yml` (`./artifacts/**/*.zip`, `./artifacts/**/*.AppImage`). The draft behaviour traced from `release-on-merge.yml` (`draft: true`) through `create-release.yml` to `draft: ${{ inputs.draft }}` on the release action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
