### PR TITLE
docs: add the missing StartLightsChanged core event

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,7 @@ To prevent circular dependencies between feature services, we use the **Mediator
         ▼                                     ▼
   ITelemetryEventBus                  Core Events:
   (Cross-feature mediator)            - DataUpdated
+        │                             - StartLightsChanged
         │                             - NewLap
         │                             - SessionTypeChanged
         │                             - SessionPhaseChanged
@@ -312,6 +313,9 @@ public class FuelService : IFuelService, IDisposable
 
 Use for session lifecycle events:
 - `DataUpdated` - Telemetry data refreshed (@60Hz)
+- `StartLightsChanged` - Start light state changed. Note the payload is
+  `Action<int>` (the light count), not `Action<TelemetryData>` like every other
+  core event
 - `NewLap` - Lap completed
 - `SessionTypeChanged` - Session type changed
 - `SessionPhaseChanged` - Session phase changed (Countdown, Formation, Green, etc.)


### PR DESCRIPTION
## Summary

`ITelemetryService` declares **eight** events; CONTRIBUTING documented seven. `StartLightsChanged` was missing from both the Core Events list and the architecture diagram.

```csharp
public interface ITelemetryService
{
    event Action<TelemetryData>? DataUpdated;
    event Action<int>? StartLightsChanged;   // <- undocumented
    event Action<TelemetryData>? NewLap;
    ...
}
```

Added in interface order (after `DataUpdated`) so the doc reads in the same sequence as the source.

## The payload is different

Worth more than a one-line mention: `StartLightsChanged` is `Action<int>` — the light count — while every other core event is `Action<TelemetryData>`. Someone writing a handler by pattern-matching the events around it in the list gets a compile error, so the list now says so explicitly.

## Verification

Checked against `R3E/Core/Interfaces/ITelemetryService.cs`, and traced the raise path: `SharedMemoryService` / `RemoteSharedMemoryService` raise it on `ISharedSource`, and `TelemetryService.SharedSource_StartLightsChanged` re-raises it. The diagram's box-drawing alignment is preserved — the new line uses the same prefix as its neighbours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)