### PR TITLE
docs: document the bugfix/ branch prefix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -452,7 +452,11 @@ We use **GitFlow** with automated versioning via GitVersion. All version numbers
 | `main` | `main` | Production releases | `1.0.0` |
 | `develop` | `develop` | Integration/staging branch | `1.1.0-beta.1` |
 | `feature/*` | `feature/name` or `features/name` | New features or improvements | `1.1.0-alpha.1` |
+| `bugfix/*` | `bugfix/name` or `bugfixes/name` | Non-critical bug fixes | `1.0.1` |
 | `hotfix/*` | `hotfix/name` or `hotfixes/name` | Critical production bug fixes | `1.0.1` |
+
+All three prefixes also accept a hyphen instead of a slash (`feature-name`,
+`bugfix-name`, `hotfix-name`), per the regexes in `GitVersion.yml`.
 
 ### Branch Naming Examples
 
@@ -564,6 +568,7 @@ Versions follow [Semantic Versioning 2.0.0](https://semver.org/): `MAJOR.MINOR.P
 - **`main`**: No pre-release tag (stable: `1.0.0`)
 - **`develop`**: Beta tag (`1.1.0-beta.1`)
 - **`feature/*`**: Alpha tag (`1.1.0-alpha.1`)
+- **`bugfix/*`**: No pre-release tag (`1.0.1`)
 - **`hotfix/*`**: No pre-release tag (`1.0.1`)
 
 ## 🛡️ Branch Protection Rules
@@ -690,7 +695,7 @@ A: Create a new feature branch from develop, make your fix, and PR back to devel
 A: No. Versions are calculated by GitVersion based on Git history and tags. To set an initial version, create a Git tag.
 
 **Q: What happens if I name my branch incorrectly?**  
-A: GitVersion won't recognize it and will use default versioning. Always use the correct prefixes: `feature/`, `hotfix/`.
+A: GitVersion won't recognize it and will use default versioning. Always use the correct prefixes: `feature/`, `bugfix/`, `hotfix/`.
 
 **Q: Should I create a new data instance on every telemetry update?**  
 A: No! Create data instances **once** and reuse them. Only update mutable fields as needed. Recreating objects @ 60Hz causes excessive GC pressure.


### PR DESCRIPTION
## Summary

`GitVersion.yml` configures a fourth branch type that CONTRIBUTING never mentioned:

```yaml
bugfix:
  regex: ^bugfix(es)?[/-]
  label: ""
  increment: Patch
  track-merge-target: false
```

The Branch Types table, the "Version Tags by Branch" list, and the FAQ answer on branch naming all named only `feature/` and `hotfix/`. A contributor branching `bugfix/something` — a perfectly valid, configured prefix — would read this file and conclude they'd got it wrong.

Adds `bugfix/*` to all three places.

## Hyphen separators

Also notes that the regexes accept a hyphen as well as a slash — `^features?[/-]`, `^bugfix(es)?[/-]`, `^hotfix(es)?[/-]` — so `feature-name` versions identically to `feature/name`. No example showed this, and the "Bad" list rules out `feature_name` (underscore) without clarifying that a hyphen is fine.

## Not changed

Left the "Automatic Increment Rules" table alone. It's framed in terms of merge direction ("Merge hotfix to main"), and I didn't want to assert where `bugfix/` branches are expected to merge without that being an established convention here. `bugfix` has `track-merge-target: false` and increments Patch, which the Version Tags list now covers.

## Verification

Read from `GitVersion.yml` at the repo root. All four configured branch entries (`main`, `develop`, `feature`, `bugfix`, `hotfix`) now appear in the doc with labels and increments matching the config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)