### PR TITLE
docs: update the outdated project structure in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ YaHud/
 │   ├── Assets/             # Tray icon
 │   ├── Linux/              # D-Bus StatusNotifierItem tray icon for Linux
 │   └── Windows/            # Windows Forms NotifyIcon tray for Windows
+├── docs/                   # AppImage packaging and Linux D-Bus tray internals
 ├── packaging/appimage/     # AppRun, desktop entry and icon for the Linux AppImage
 ├── scripts/                # Developer scripts (headless tray D-Bus test)
 ├── git/hooks/              # Pre-push hooks

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Click the ℹ️ (info) icon to view credits and third-party licenses.
 
 ## 🏗️ Architecture
 
-The project consists of three main components:
+The project consists of four components:
 
 ### R3E.YaHud
 The main Blazor web application that renders the HUD overlay.
@@ -147,12 +147,18 @@ The main Blazor web application that renders the HUD overlay.
 Core library containing:
 
 - RaceRoom shared memory API definitions
-- Telemetry data processing
+- Telemetry data processing and the cross-feature event bus
+- Feature services (fuel, radar, sector, time gap, driver, tyres)
 - Cross-platform data source interfaces
-- Unit converters (speed, temperature, angular velocity)
+- Unit converters (speed, temperature, pressure, angular velocity)
 
 ### R3E.Relay
 Windows service that forwards RaceRoom shared memory data via UDP for cross-platform support.
+
+### R3E.Tray
+System tray icon, with separate implementations per platform: Windows Forms
+`NotifyIcon` on Windows, and the freedesktop StatusNotifierItem D-Bus protocol on
+Linux.
 
 ## 🛠️ Development
 
@@ -201,21 +207,35 @@ dotnet publish R3E.Relay/R3E.Relay.csproj -c Release -r win-x64 --self-contained
 ### Project Structure
 
 ```
-R3E/
+YaHud/
 ├── R3E.YaHud/              # Main Blazor HUD application
 │   ├── Components/
+│   │   ├── Layout/         # App layout
 │   │   ├── Pages/          # Blazor pages
-│   │   ├── UI/             # UI components
-│   │   └── Widget/         # HUD widgets
-│   ├── Services/           # Application services
+│   │   ├── UI/             # Shared UI components and helpers
+│   │   └── Widget/         # HUD widgets — one folder each, plus Core/
+│   ├── Services/           # Application services (incl. Settings/)
 │   └── wwwroot/            # Static assets
 ├── R3E/                    # Core library
-│   └── API/                # RaceRoom API and telemetry
-├── R3E.Relay/              # UDP relay service
-└── R3E.Tray/               # Tray service
-    ├── Assets              # Contains icon for tray service
-    ├── Linux               # D-Bus StatusNotifierItem tray icon for Linux
-    └── Windows             # Windows Forms code for tray app for Windows
+│   ├── Core/
+│   │   ├── Interfaces/     # ITelemetryService, ITelemetryEventBus, ISharedSource
+│   │   ├── Services/       # TelemetryService, TelemetryEventBus, TelemetryData
+│   │   └── SharedMemory/   # SharedMemoryService (Windows), RemoteSharedMemoryService (UDP)
+│   ├── Features/           # Feature service + data class pairs (Fuel, Radar, Sector, …)
+│   ├── Converters/         # Unit converters (speed, temperature, pressure, angular)
+│   ├── Networking/         # UDP receiver
+│   ├── Extensions/         # Extension methods
+│   └── Utilities/          # Shared helpers
+├── R3E.Relay/              # UDP relay service (Windows)
+│   └── Service/            # UdpRelayService
+├── R3E.Tray/               # Tray service
+│   ├── Assets/             # Tray icon
+│   ├── Linux/              # D-Bus StatusNotifierItem tray icon for Linux
+│   └── Windows/            # Windows Forms NotifyIcon tray for Windows
+├── packaging/appimage/     # AppRun, desktop entry and icon for the Linux AppImage
+├── scripts/                # Developer scripts (headless tray D-Bus test)
+├── git/hooks/              # Pre-push hooks
+└── images/                 # Logo and README images
 ```
 
 ### Creating Custom Widgets


### PR DESCRIPTION
## Summary

The Project Structure tree described a layout that no longer exists. Docs only.

## The core library was reorganised and the tree never caught up

It showed:

```
├── R3E/                    # Core library
│   └── API/                # RaceRoom API and telemetry
```

`R3E/API/` doesn't exist. The actual layout is six directories, none of which appeared:

```
├── R3E/
│   ├── Core/               # Interfaces/, Services/, SharedMemory/
│   ├── Features/           # Feature service + data class pairs
│   ├── Converters/
│   ├── Networking/
│   ├── Extensions/
│   └── Utilities/
```

`Core/` is now expanded one level further, since `Interfaces/`, `Services/` and `SharedMemory/` are the split that the CONTRIBUTING architecture section refers to — it was impossible to map that doc onto this tree.

## Other fixes in the same tree

- **Root renamed `R3E/` → `YaHud/`.** It's the repo root, and calling it `R3E/` collided with the `R3E/` project nested inside it.
- **Missing directories added** that existed all along: `Components/Layout/`, `Services/Settings/`, `R3E.Relay/Service/`, plus the top-level `packaging/`, `scripts/`, `git/hooks/` and `images/`.
- Trailing-slash consistency on the `R3E.Tray` entries.

## Architecture section

It opened with "The project consists of **three** main components" and documented `R3E.YaHud`, `R3E`, and `R3E.Relay` — omitting `R3E.Tray`, which is a fourth project in the solution. Added it, and refreshed the `R3E` bullets to mention the event bus and feature services (and `pressure`, now that a unit converter for it exists).

## The tree describes the post-merge state

Two entries are intentionally written for how the repo will look once the sibling PRs land, rather than how `develop` looks right now:

- **`docs/` is listed** — it arrives with #96 (`docs/appimage.md`) and #97 (`docs/linux-tray-dbus.md`).
- **`Relay-Python/` is not listed** — #94 deletes it.

So this PR should merge alongside #94, #96 and #97. If any of those three is rejected, the corresponding row here needs adjusting.

## Verification

Every other path in the new tree was confirmed to exist with `find`/`ls` — including the file-level claims (`UdpRelayService.cs`, `TelemetryEventBus.cs`, `SharedMemoryService.cs`/`RemoteSharedMemoryService.cs`, the `FuelData.cs`/`FuelService.cs` pairing, and the two `git/hooks` scripts). Confirmed this branch merges cleanly with #96 and #97, the other two README-touching PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
