### PR TITLE
Add launch arguments for the web port, telemetry port and transport

### DIFF
--- a/R3E.Relay/Program.cs
+++ b/R3E.Relay/Program.cs
@@ -2,6 +2,8 @@
 using R3E.Core.SharedMemory;
 using R3E.Data;
 using R3E.Relay.Service;
+using R3E.Utilities;
+using System.CommandLine;
 using System.Net;
 using System.Runtime.InteropServices;
 
@@ -17,7 +19,7 @@ internal class Program : IDisposable
     private readonly byte[] sendBuffer;
     private readonly int bufferSize;
 
-    public Program()
+    public Program(string targetHost, int targetPort)
     {
         // keep logger factory alive for the lifetime of the program
         loggerFactory = LoggerFactory.Create(lb => lb.AddConsole());
@@ -27,7 +29,7 @@ internal class Program : IDisposable
 
         sharedMemoryService = new SharedMemoryService(shmLogger);
         int sourcePort = GetAvailablePort();
-        udpRelayService = new UdpRelayService(sourcePort, "127.0.0.1", 10101, udpLogger);
+        udpRelayService = new UdpRelayService(sourcePort, targetHost, targetPort, udpLogger);
 
         // Allocate buffer once for the lifetime of the program
         bufferSize = Marshal.SizeOf<Shared>();
@@ -125,11 +127,45 @@ internal class Program : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    static async Task Main()
+    static async Task<int> Main(string[] args)
     {
+        var udpPortOption = LaunchOptions.CreatePortOption(
+            "--udp-port", "UDP port to send telemetry to. Must match the HUD's --udp-port.",
+            RemoteSharedMemoryService.DefaultUdpPort);
+        var udpHostOption = new Option<string>("--udp-host")
+        {
+            Description = "IP address to send telemetry to. Use the HUD machine's address when it is not on this machine.",
+            DefaultValueFactory = _ => "127.0.0.1",
+            HelpName = "ip",
+        };
+        udpHostOption.Validators.Add(result =>
+        {
+            // UdpRelayService parses this with IPAddress.Parse, which would throw on a hostname.
+            var value = result.GetValueOrDefault<string>();
+            if (!IPAddress.TryParse(value, out _))
+            {
+                result.AddError($"--udp-host must be an IP address (hostnames are not supported), but was '{value}'.");
+            }
+        });
+
+        var rootCommand = new RootCommand("R3E relay - forwards RaceRoom shared memory to YaHud over UDP.");
+        rootCommand.Options.Add(udpPortOption);
+        rootCommand.Options.Add(udpHostOption);
+
+        var parsed = rootCommand.Parse(args);
+        if (parsed.Errors.Count > 0 || parsed.Action is not null)
+        {
+            // Invalid input, --help or --version: print the parser's own output and exit.
+            return parsed.Invoke();
+        }
+
+        var targetHost = parsed.GetValue(udpHostOption)!;
+        var targetPort = parsed.GetValue(udpPortOption);
+
         Console.WriteLine("Starting R3E API UDP relay service");
+        Console.WriteLine($"Relaying R3E shared memory to {targetHost}:{targetPort}");
         Console.WriteLine("Waiting for R3E to start");
-        using var program = new Program();
+        using var program = new Program(targetHost, targetPort);
 
         // Use a CancellationTokenSource to allow graceful shutdown
         using var cts = new CancellationTokenSource();
@@ -156,5 +192,7 @@ internal class Program : IDisposable
             // Stop the background service gracefully
             await program.sharedMemoryService.StopAsync(CancellationToken.None);
         }
+
+        return 0;
     }
 }

--- a/R3E.YaHud/Program.cs
+++ b/R3E.YaHud/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Components.Server;
+using Microsoft.AspNetCore.Connections;
 using R3E.Core.Interfaces;
 using R3E.Core.Services;
 using R3E.Core.SharedMemory;
@@ -12,8 +13,86 @@ using R3E.Tray;
 using R3E.Features.TireWidget;
 using R3E.YaHud.Services;
 using R3E.YaHud.Services.Settings;
+using R3E.Utilities;
+using System.CommandLine;
 
-var builder = WebApplication.CreateBuilder(args);
+var webPortOption = LaunchOptions.CreatePortOption(
+    "--web-port", "Port the web HUD listens on.", 5000);
+var udpPortOption = LaunchOptions.CreatePortOption(
+    "--udp-port", "UDP port the telemetry receiver listens on. Must match the relay's --udp-port.",
+    RemoteSharedMemoryService.DefaultUdpPort);
+var forceUdpOption = new Option<bool>("--force-udp")
+{
+    Description = "Receive telemetry over UDP from the relay instead of reading shared memory directly (Windows only; it is already the default elsewhere).",
+};
+
+var rootCommand = new RootCommand("YaHud - a web HUD for RaceRoom Racing Experience.")
+{
+    // Host arguments such as --urls, --environment and --contentRoot must keep working, so
+    // anything we do not recognise is forwarded to the web host rather than rejected here.
+    TreatUnmatchedTokensAsErrors = false,
+};
+rootCommand.Options.Add(webPortOption);
+rootCommand.Options.Add(udpPortOption);
+rootCommand.Options.Add(forceUdpOption);
+
+var parsed = rootCommand.Parse(args);
+if (parsed.Errors.Count > 0 || parsed.Action is not null)
+{
+    // Invalid input, --help or --version: print the parser's own output and exit.
+    return parsed.Invoke();
+}
+
+var builder = WebApplication.CreateBuilder(new WebApplicationOptions
+{
+    // Only the arguments we did not claim; a valueless flag like --force-udp would otherwise
+    // make the host's own command line configuration provider throw.
+    Args = [.. parsed.UnmatchedTokens],
+});
+
+// Launch arguments win over appsettings.json, but only where the user actually supplied one -
+// otherwise the file keeps providing the defaults.
+var overrides = new Dictionary<string, string?>();
+if (parsed.GetResult(webPortOption) is { Implicit: false })
+{
+    overrides["YaHud:WebPort"] = parsed.GetValue(webPortOption).ToString();
+}
+if (parsed.GetResult(udpPortOption) is { Implicit: false })
+{
+    overrides["YaHud:Udp:Port"] = parsed.GetValue(udpPortOption).ToString();
+}
+if (parsed.GetResult(forceUdpOption) is { Implicit: false })
+{
+    overrides["YaHud:Udp:ForceUdp"] = parsed.GetValue(forceUdpOption).ToString();
+}
+builder.Configuration.AddInMemoryCollection(overrides);
+
+// Read through the same validation as the launch arguments: these values may also come from
+// appsettings.json, where a typo would otherwise surface as an unhandled conversion exception.
+if (!LaunchOptions.TryReadPort(builder.Configuration["YaHud:WebPort"], "--web-port (or YaHud:WebPort)", 5000, out var webPort, out var configError)
+    || !LaunchOptions.TryReadPort(builder.Configuration["YaHud:Udp:Port"], "--udp-port (or YaHud:Udp:Port)", RemoteSharedMemoryService.DefaultUdpPort, out var udpPort, out configError))
+{
+    Console.Error.WriteLine(configError);
+    return 1;
+}
+
+var rawForceUdp = builder.Configuration["YaHud:Udp:ForceUdp"];
+if (!string.IsNullOrWhiteSpace(rawForceUdp) && !bool.TryParse(rawForceUdp, out _))
+{
+    Console.Error.WriteLine($"--force-udp (or YaHud:Udp:ForceUdp) must be true or false, but was '{rawForceUdp}'.");
+    return 1;
+}
+var forceUdp = bool.TryParse(rawForceUdp, out var parsedForceUdp) && parsedForceUdp;
+
+// UseUrls overrides --urls and ASPNETCORE_URLS, so only bind explicitly when the user asked for a
+// port or nothing else has set the URLs.
+var hudUrl = $"http://localhost:{webPort}";
+var bindHudUrl = !string.IsNullOrEmpty(overrides.GetValueOrDefault("YaHud:WebPort"))
+    || string.IsNullOrEmpty(builder.Configuration["urls"]);
+if (bindHudUrl)
+{
+    builder.WebHost.UseUrls(hudUrl);
+}
 
 builder.Logging.ClearProviders();
 builder.Logging.AddConfiguration(builder.Configuration.GetSection("Logging"));
@@ -43,8 +122,8 @@ builder.Services.AddScoped<VisibilityService>();
 builder.Services.AddScoped<TestModeService>();
 builder.Services.AddSingleton<ShortcutService>();
 
-// Register appropriate ISharedSource based on OS
-if (OperatingSystem.IsWindows())
+// Register appropriate ISharedSource based on OS, unless --force-udp overrides it
+if (OperatingSystem.IsWindows() && !forceUdp)
 {
     builder.Services.AddSingleton<SharedMemoryService>();
     builder.Services.AddSingleton<ISharedSource>(sp =>
@@ -62,7 +141,7 @@ if (OperatingSystem.IsWindows())
 }
 else
 {
-    builder.Services.AddSingleton<RemoteSharedMemoryService>();
+    builder.Services.AddSingleton(sp => new RemoteSharedMemoryService(udpPort, sp.GetRequiredService<ILoggerFactory>()));
     builder.Services.AddSingleton<ISharedSource>(sp => sp.GetRequiredService<RemoteSharedMemoryService>());
     builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<RemoteSharedMemoryService>());
 }
@@ -83,6 +162,15 @@ builder.Services.AddSingleton<TireWidgetService>();
 builder.Services.AddTrayService();
 
 var app = builder.Build();
+
+if (bindHudUrl)
+{
+    app.Logger.LogInformation("YaHud web HUD listening on {Url}", hudUrl);
+}
+if (forceUdp && OperatingSystem.IsWindows())
+{
+    app.Logger.LogWarning("--force-udp is set: receiving telemetry over UDP on port {Port} instead of reading shared memory. The relay must be running.", udpPort);
+}
 
 // Last-resort safety net: a fault in a background task (e.g. a widget update or a telemetry
 // callback) must never tear down the process, since the Blazor UI and the UDP telemetry
@@ -110,4 +198,16 @@ app.MapRazorComponents<R3E.YaHud.Components.App>()
     .AddInteractiveServerRenderMode()
     .WithStaticAssets();
 
-app.Run();
+try
+{
+    app.Run();
+}
+catch (IOException ex) when (ex.InnerException is AddressInUseException)
+{
+    // Picking a port is now a supported thing to do, so a clash deserves an explanation rather
+    // than a stack trace.
+    app.Logger.LogError("Port {Port} is already in use. Another program - possibly a second copy of YaHud - is listening on it. Start YaHud with --web-port=<port> to use a different one.", webPort);
+    return 1;
+}
+
+return 0;

--- a/R3E.YaHud/appsettings.json
+++ b/R3E.YaHud/appsettings.json
@@ -8,5 +8,12 @@
       "R3E.API.TimeGap": "Debug"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "YaHud": {
+    "WebPort": 5000,
+    "Udp": {
+      "Port": 10101,
+      "ForceUdp": false
+    }
+  }
 }

--- a/R3E/Core/SharedMemory/RemoteSharedMemoryService.cs
+++ b/R3E/Core/SharedMemory/RemoteSharedMemoryService.cs
@@ -8,9 +8,15 @@ namespace R3E.Core.SharedMemory
     // Hosted service that exposes remote shared memory via UDP
     public class RemoteSharedMemoryService : ISharedSource, IHostedService, IAsyncDisposable
     {
+        /// <summary>
+        /// UDP port used when no <c>--udp-port</c> launch argument is supplied. The relay defaults
+        /// to the same value, so both ends stay in sync out of the box.
+        /// </summary>
+        public const int DefaultUdpPort = 10101;
+
         private readonly ILogger<RemoteSharedMemoryService> logger;
         private readonly UdpReceiver receiver;
-        private readonly int port = 10101;
+        private readonly int port;
         private Task? pollTask;
         private CancellationTokenSource? receiverCts;
         private bool disposed;
@@ -21,10 +27,13 @@ namespace R3E.Core.SharedMemory
 
         public Shared Data { get; private set; }
 
-        public RemoteSharedMemoryService(ILogger<RemoteSharedMemoryService>? logger = null)
+        public RemoteSharedMemoryService(int port = DefaultUdpPort, ILoggerFactory? loggerFactory = null)
         {
-            this.logger = logger ?? NullLogger<RemoteSharedMemoryService>.Instance;
-            receiver = new UdpReceiver(port, NullLogger<UdpReceiver>.Instance);
+            this.port = port;
+            this.logger = loggerFactory?.CreateLogger<RemoteSharedMemoryService>() ?? NullLogger<RemoteSharedMemoryService>.Instance;
+            // UdpReceiver logs the port it actually bound to, which is the confirmation that
+            // --udp-port took effect, so give it a real logger rather than a null one.
+            receiver = new UdpReceiver(port, loggerFactory?.CreateLogger<UdpReceiver>() ?? NullLogger<UdpReceiver>.Instance);
             receiver.DataReceived += OnDataReceived;
             Data = new Shared();
             this.logger.LogDebug("RemoteSharedMemoryService constructed, listening on port {Port}", port);

--- a/R3E/R3E.csproj
+++ b/R3E/R3E.csproj
@@ -12,5 +12,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="System.CommandLine" Version="2.0.10" />
   </ItemGroup>
 </Project>

--- a/R3E/Utilities/LaunchOptions.cs
+++ b/R3E/Utilities/LaunchOptions.cs
@@ -1,0 +1,80 @@
+using System.CommandLine;
+
+namespace R3E.Utilities
+{
+    /// <summary>
+    /// Launch argument definitions shared by the HUD and the relay, so the two ends of the
+    /// telemetry link cannot drift apart on naming, defaults or validation.
+    /// </summary>
+    public static class LaunchOptions
+    {
+        public const int MinPort = 1;
+        public const int MaxPort = 65535;
+
+        /// <summary>
+        /// Creates a port option that only accepts a valid TCP/UDP port number.
+        /// </summary>
+        public static Option<int> CreatePortOption(string name, string description, int defaultPort)
+        {
+            var option = new Option<int>(name)
+            {
+                Description = description,
+                DefaultValueFactory = _ => defaultPort,
+                HelpName = "port",
+            };
+
+            option.Validators.Add(result =>
+            {
+                // Validate the raw token rather than the converted value: reading a value that
+                // failed conversion (e.g. --web-port=abc) throws instead of reporting an error.
+                var token = result.Tokens.Count > 0 ? result.Tokens[0].Value : null;
+                if (token is null)
+                {
+                    return;
+                }
+
+                if (!int.TryParse(token, out var value))
+                {
+                    result.AddError($"{name} must be a whole number between {MinPort} and {MaxPort}, but was '{token}'.");
+                }
+                else if (value is < MinPort or > MaxPort)
+                {
+                    result.AddError($"{name} must be between {MinPort} and {MaxPort}, but was {value}.");
+                }
+            });
+
+            return option;
+        }
+
+        /// <summary>
+        /// Validates a port that came from configuration rather than the command line, so a typo in
+        /// appsettings.json reports the same friendly error instead of an unhandled conversion
+        /// exception. An absent or empty value falls back to <paramref name="defaultPort"/>.
+        /// </summary>
+        public static bool TryReadPort(string? rawValue, string source, int defaultPort, out int port, out string? error)
+        {
+            error = null;
+            port = defaultPort;
+
+            if (string.IsNullOrWhiteSpace(rawValue))
+            {
+                return true;
+            }
+
+            if (!int.TryParse(rawValue, out var value))
+            {
+                error = $"{source} must be a whole number between {MinPort} and {MaxPort}, but was '{rawValue}'.";
+                return false;
+            }
+
+            if (value is < MinPort or > MaxPort)
+            {
+                error = $"{source} must be between {MinPort} and {MaxPort}, but was {value}.";
+                return false;
+            }
+
+            port = value;
+            return true;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A modern, customizable HUD (Heads-Up Display) overlay for RaceRoom Racing Experi
 Add the following launch option to RaceRoom (required for all platforms):
 
 ```
--webHudUrl=http://localhost:5019/
+-webHudUrl=http://localhost:5000/
 ```
 
 To add launch options in Steam:
@@ -57,6 +57,47 @@ To add launch options in Steam:
 1. Right-click RaceRoom Racing Experience in your library
 2. Select "Properties"
 3. In the "General" tab, add the launch option to the "Launch Options" field
+
+If you change the HUD's port with `--web-port` (see below), change this launch
+option to match.
+
+#### Launch arguments
+
+Both executables accept launch arguments; run either with `--help` for the full list.
+
+| Argument | Applies to | Default | Purpose |
+| --- | --- | --- | --- |
+| `--web-port=<port>` | YaHud | `5000` | Port the web HUD listens on |
+| `--udp-port=<port>` | YaHud, R3ERelay | `10101` | Telemetry UDP port — **must match on both** |
+| `--udp-host=<ip>` | R3ERelay | `127.0.0.1` | IP address the relay sends telemetry to |
+| `--force-udp` | YaHud | off | Receive telemetry over UDP from the relay instead of reading shared memory directly (Windows only — it is already the default elsewhere) |
+
+Examples:
+
+```bash
+# Serve the HUD on port 8080 instead (remember to update -webHudUrl to match)
+YaHud.exe --web-port=8080
+
+# Use a different telemetry port - both sides must agree
+R3ERelay.exe --udp-port=10200
+./YaHud --udp-port=10200
+
+# Run the relay on the gaming PC and the HUD on another machine
+R3ERelay.exe --udp-port=10200 --udp-host=192.168.1.50
+```
+
+YaHud also reads these values from the `appsettings.json` next to its executable,
+under the `YaHud` section, if you would rather not edit a shortcut. A launch
+argument always wins over the file:
+
+```json
+"YaHud": {
+  "WebPort": 5000,
+  "Udp": { "Port": 10101, "ForceUdp": false }
+}
+```
+
+The relay has no configuration file — it takes launch arguments only.
 
 #### Windows (Native)
 
@@ -106,10 +147,16 @@ STEAM_COMPAT_DATA_PATH="/$HOME/.local/share/Steam/steamapps/compatdata/211500" \
 
 > **Note**: Adjust the Proton version (e.g., `GE-Proton10-4`) to match the version you're using for RaceRoom.
 
+> **Note**: Launch arguments go after the executable, e.g.
+> `"C:\Program Files\R3ERelay\R3ERelay.exe" --udp-port=10200`.
+
 3. On your Linux machine, run the HUD application — either the AppImage (see
 above) or the plain binary from `R3E.YaHud-linux-x64-v{version}.zip`:
 ```bash
 ./YaHud
+
+# ...or with a different telemetry port, matching the relay's --udp-port
+./YaHud --udp-port=10200
 ```
 
 The relay service forwards RaceRoom's shared memory data over UDP, allowing the HUD to run natively on Linux.

--- a/docs/appimage.md
+++ b/docs/appimage.md
@@ -174,7 +174,8 @@ chmod +x ./YaHud-v${VERSION}-x86_64.AppImage
 ./YaHud-v${VERSION}-x86_64.AppImage
 ```
 
-Then browse to <http://localhost:5019/>.
+Then browse to <http://localhost:5000/> (or the port you passed with `--web-port`;
+`AppRun` forwards all arguments to the binary).
 
 Useful inspection commands:
 


### PR DESCRIPTION
Closes #61.

Every network endpoint was fixed at compile time. The web HUD fell back to ASP.NET Core's default port because nothing set a listen URL, the UDP telemetry port was hard-coded in `RemoteSharedMemoryService`, the relay hard-coded its destination and its `Main` did not even take arguments, and the shared-memory/UDP choice came purely from the host OS.

## Arguments

| Argument | Applies to | Default | Purpose |
| --- | --- | --- | --- |
| `--web-port=<port>` | YaHud | `5000` | Port the web HUD listens on |
| `--udp-port=<port>` | YaHud, R3ERelay | `10101` | Telemetry UDP port — must match on both |
| `--udp-host=<ip>` | R3ERelay | `127.0.0.1` | Where the relay sends telemetry |
| `--force-udp` | YaHud | off | Use the relay instead of shared memory on Windows |

Parsed with `System.CommandLine` 2.0.10 (latest stable; the 3.0 line is preview-only), so `--help` and range validation are generated rather than hand-written. YaHud also reads the values from `appsettings.json` under a `YaHud` section; a launch argument wins. Both sources get the same validation.

`--force-udp` makes the UDP path reachable on Windows, which previously could not be exercised there at all.

## Notes for review

- **Unrecognised arguments are forwarded to the web host** rather than rejected, so `--urls`, `--environment` and `scripts/test-tray-dbus.sh` keep working. The cost is that a typo like `--web-prot=8080` is ignored instead of erroring; the four documented options are still strictly validated.
- **Two crash paths fixed along the way**: a bad value in `appsettings.json` and a port that is already in use both used to produce raw stack traces. Both now print an actionable message and exit non-zero.
- **`README.md` and `docs/appimage.md` told users to point RaceRoom at `localhost:5019`** — a port nothing in the codebase ever bound. Corrected to 5000 rather than changing runtime behaviour.
- `RemoteSharedMemoryService`'s constructor signature changed (port + `ILoggerFactory`); the only call site is `R3E.YaHud/Program.cs`. It now passes a real logger through to `UdpReceiver`, so the bound UDP port actually appears in the log.

## Verification

Manual — the repo has no test project.

- Release builds on Windows and Linux; WSL D-Bus tray suite passes.
- `--help` on both binaries; default 5000; `--web-port` in `=` and space forms; `appsettings.json` layering and argument precedence; `--force-udp --udp-port=10200` switching transport on Windows and logging `Listening on UDP port 10200`; `--urls` passthrough; relay banner with default and custom target.
- Invalid input exits 1 with a clear message: non-numeric, `0`, `99999`, missing value, duplicate option, bad `--udp-host`, bad `appsettings.json` values, port in use.

**Not verified:** live telemetry with RaceRoom actually running on a non-default port — everything up to "receiver bound to the requested port" is confirmed, but the end-to-end data flow needs the game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)