### PR TITLE
Unstick release versioning and make the increment selectable

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: cut-release
+description: Open the develop → main release PR for YaHud and publish the resulting release. Use whenever cutting a release, shipping develop to main, bumping the version, or publishing a draft release. Covers choosing the major/minor/patch increment, which is silent if you get it wrong.
+---
+
+# Cutting a YaHud release
+
+A release is a PR from `develop` to `main`. Merging it triggers
+`release-on-merge.yml`, which builds artifacts and creates a **draft** release.
+
+Two steps here fail silently — no check goes red, you just get the wrong
+result. They are steps 2 and 5.
+
+## 1. Confirm develop is ready
+
+```bash
+git fetch origin
+gh pr list --base develop --state open          # anything that should land first?
+git log --oneline origin/main..origin/develop   # what is shipping
+```
+
+## 2. Decide the increment — this is the silent one
+
+`main` is configured `increment: Patch`, so **the default is a patch release**.
+To ship anything else, the marker goes in the **PR title**:
+
+| You want | PR title | Result from `0.2.0` |
+|----------|----------|---------------------|
+| Patch | `Release 0.2.1` | `0.2.1` |
+| Minor | `Release 0.3.0 +semver: minor` | `0.3.0` |
+| Major | `Release 1.0.0 +semver: major` | `1.0.0` |
+
+**The title is what matters, not the body.** This repo sets
+`merge_commit_message: PR_TITLE`, so GitHub copies the PR title into the merge
+commit body, which is where GitVersion reads it. Nothing else in the PR is read.
+
+A marker can only *raise* the increment above `main`'s `increment: Patch`,
+never lower it — `+semver: patch` is a no-op, and there is no way to suppress a
+bump on a merge to `main`. See [Version Numbering](../../../CONTRIBUTING.md#-version-numbering)
+for why.
+
+Most `develop` → `main` releases are feature work and want `+semver: minor`.
+Getting this wrong is not fatal but is annoying to undo: the version comes from
+tags, so correcting it means deleting the pushed tag and release.
+
+Check what you are about to get before opening the PR:
+
+```bash
+dotnet tool install --global GitVersion.Tool --version 6.4.*   # once
+dotnet-gitversion /showvariable MajorMinorPatch
+```
+
+That reports the version for the *current* branch, so it will not reflect the
+marker. Use it to confirm the baseline you are incrementing from.
+
+## 3. Open the PR
+
+Base is `main`, not `develop` — this is the one exception to the rule in the
+`pull-request` skill.
+
+```bash
+gh pr create --base main --head develop \
+  --title "Release 0.3.0 +semver: minor" \
+  --body "..."
+gh pr edit <number> --add-label release
+```
+
+Label it **`release`**. `.github/release.yml` excludes that label from the
+generated notes; without it the release PR itself appears in its own changelog
+alongside every PR it contains.
+
+Body should summarise what is shipping — `git log --oneline origin/main..origin/develop`
+is a good starting point.
+
+## 4. Merge with a merge commit
+
+```bash
+gh pr merge <number> --merge
+```
+
+**Not `--squash`, not `--rebase`.** Squashing flattens the branch history that
+GitVersion walks to find the version source and the `+semver` marker. Confirm
+the marker survived:
+
+```bash
+git fetch origin main && git log -1 --format=%B origin/main
+```
+
+The body should contain your `+semver:` line. If it does not, the release will
+be a patch — stop and fix it before the workflow finishes.
+
+## 5. Publish the draft — the other silent one
+
+`release-on-merge.yml` passes `draft: true`, so **the release and its tag are
+not public until someone publishes them.** The workflow going green does not
+mean the release shipped.
+
+```bash
+gh release list --limit 5              # confirm the draft and its version
+gh release view v0.3.0                 # check notes and attached artifacts
+gh release edit v0.3.0 --draft=false   # publish
+```
+
+(There is no `gh release publish` — clearing the draft flag is what publishes.)
+
+Expect four artifacts (see [Artifacts Published](../../../CONTRIBUTING.md#artifacts-published)):
+two Windows zips, one Linux zip, one AppImage. A release with fewer means a
+build leg failed — investigate before publishing rather than shipping a partial
+release.
+
+## 6. Back-merge to develop
+
+`main` now has a merge commit that `develop` lacks. Leaving them diverged makes
+the next release's version calculation harder to reason about.
+
+```bash
+git checkout develop && git pull
+git merge origin/main
+git push origin develop
+```
+
+## Notes
+
+- **Hotfixes skip all of this.** A `hotfix/*` branch PRs straight to `main` and
+  needs no marker — patch is the default. Steps 5 and 6 still apply.
+- **Tags must be plain `vMAJOR.MINOR.PATCH`.** A pre-release tag on `main` is
+  not a valid version source, and GitVersion will silently recompute the same
+  version on every subsequent release. This is what the `v0.1.0-463` through
+  `v0.1.0-614` tags did.
+- **`next-version:` in `GitVersion.yml`** overrides the markers while it is the
+  active baseline. If a marker appears to do nothing, check whether that line is
+  still set above the current tag.

--- a/.claude/skills/pull-request/SKILL.md
+++ b/.claude/skills/pull-request/SKILL.md
@@ -59,6 +59,10 @@ that happens to touch both does not need either.
 
 Base branch is `develop` (see CONTRIBUTING.md); only release PRs target `main`.
 
+> Cutting a release (`develop` → `main`) has extra requirements that fail
+> silently — the version increment goes in the PR title, and the resulting
+> release is a draft. Use the `cut-release` skill for those, not this one.
+
 ```bash
 gh pr create --base develop \
   --title "..." \

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -23,7 +23,7 @@ jobs:
     needs: version
     uses: ./.github/workflows/build-artifacts.yml
     with:
-      version: ${{ needs.version.outputs.semVer }}
+      version: ${{ needs.version.outputs.majorMinorPatch }}
 
   # Step 3: Create release with artifacts
   release:
@@ -31,7 +31,7 @@ jobs:
     needs: [version, build]
     uses: ./.github/workflows/create-release.yml
     with:
-      version: ${{ needs.version.outputs.semVer }}
+      version: ${{ needs.version.outputs.majorMinorPatch }}
       draft: true
       prerelease: false
     permissions:
@@ -48,7 +48,7 @@ jobs:
         run: |
           echo "### Release Pipeline Complete!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** v${{ needs.version.outputs.semVer }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** v${{ needs.version.outputs.majorMinorPatch }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Artifacts Built:**" >> $GITHUB_STEP_SUMMARY
           echo "- R3E.Relay (Windows x64)" >> $GITHUB_STEP_SUMMARY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -505,12 +505,16 @@ All three prefixes also accept a hyphen instead of a slash (`feature-name`,
    - Creates beta version (e.g., 1.1.0-beta.1)
 
 5. When ready for release, create PR from develop to main
+   - Put "+semver: minor" (or "+semver: major") in the PR TITLE, or you
+     get a patch release — see Release Process below
+   - Label it "release"
    - Version Preview will show final release version
    - Build Validation will run
 
-6. Merge to main
-   - Automatically creates GitHub release
-   - Builds and publishes artifacts
+6. Merge to main with a merge commit (not squash)
+   - Automatically creates a DRAFT GitHub release
+   - Builds and attaches artifacts
+   - Publish the draft yourself from the Releases page
 ```
 
 ### Hotfix for Production
@@ -544,6 +548,27 @@ All three prefixes also accept a hyphen instead of a slash (`feature-name`,
 
 Releases are **built automatically** when commits land on `main`, then published
 manually — see the note on drafts below.
+
+### Cutting a Release
+
+A release is a PR from `develop` to `main`. Two steps in that process fail
+**silently** — nothing goes red, you just get the wrong result:
+
+1. **The increment lives in the PR title.** `main` defaults to a patch bump, so
+   a feature release needs `+semver: minor` in the title of the release PR.
+   This repo sets `merge_commit_message: PR_TITLE`, so GitHub copies the PR
+   title into the merge commit body, which is where GitVersion reads it — the
+   PR body and description are not read. See
+   [Choosing the Increment](#choosing-the-increment).
+2. **The release is a draft.** A green workflow does not mean the release
+   shipped; someone has to publish it.
+
+Also: label the release PR `release` so it is excluded from its own changelog,
+and merge with a **merge commit**, not a squash — squashing flattens the history
+GitVersion walks to find the version source and the marker.
+
+> The `cut-release` skill in `.claude/skills/` walks through this end to end,
+> including the back-merge to `develop` afterwards.
 
 ### What Happens on Merge to Main
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -580,8 +580,37 @@ Versions follow [Semantic Versioning 2.0.0](https://semver.org/): `MAJOR.MINOR.P
 | Action | Version Change | Example |
 |--------|---------------|---------|
 | Merge feature to develop | Minor + beta tag | `1.0.0` → `1.1.0-beta.1` |
-| Merge develop to main | Minor (stable) | `1.0.0` → `1.1.0` |
 | Merge hotfix to main | Patch | `1.0.0` → `1.0.1` |
+| Merge develop to main | Patch, unless marked (see below) | `1.0.0` → `1.0.1` |
+
+### Choosing the Increment
+
+`main` is configured with `increment: Patch`, so a merge to `main` is a patch
+release by default. To ship a minor or major release instead, add a marker to
+the merge commit message (or the squashed PR title) landing on `main`:
+
+| Marker | Effect | Example |
+|--------|--------|---------|
+| `+semver: major` (or `breaking`) | Major bump | `0.2.0` → `1.0.0` |
+| `+semver: minor` (or `feature`) | Minor bump | `0.2.0` → `0.3.0` |
+| _(no marker)_ | Patch bump | `0.2.0` → `0.2.1` |
+
+**A marker can only raise the increment, never lower it below main's
+`increment:`.** That is why `main` is set to `Patch` — on `Minor` a patch
+release would be unreachable and `+semver: patch` would silently do nothing.
+The practical consequence: a `develop` → `main` release PR needs an explicit
+`+semver: minor`, while a hotfix needs no marker.
+
+For a one-off jump to a new baseline (for example cutting `1.0.0`), set
+`next-version:` in `GitVersion.yml`. It is a floor, and while it is the active
+baseline it suppresses the `+semver` markers; once a higher release tag exists
+GitVersion increments from the tag and the setting becomes a no-op.
+
+> Release tags must be plain `vMAJOR.MINOR.PATCH`. A pre-release tag on `main`
+> (like the historical `v0.1.0-614`) is not a valid version source, so
+> GitVersion ignores it and recomputes the same version on every release. This
+> is why `release-on-merge.yml` tags with `majorMinorPatch` rather than `semVer`
+> — on `main`, `semVer` still carries a numeric pre-release suffix.
 
 ### Version Tags by Branch
 
@@ -776,7 +805,7 @@ A: No. Features must go through `develop` first, then `develop` → `main`.
 A: Create a new feature branch from develop, make your fix, and PR back to develop.
 
 **Q: Can I manually set the version number?**  
-A: No. Versions are calculated by GitVersion based on Git history and tags. To set an initial version, create a Git tag.
+A: Not directly — versions are calculated by GitVersion from Git history and tags. You can steer it three ways: a `+semver:` marker in the merge commit message to change one release's increment, `next-version:` in `GitVersion.yml` to set a new baseline, or a Git tag (`v1.2.0`) to pin the version source. See [Version Numbering](#-version-numbering).
 
 **Q: What happens if I name my branch incorrectly?**  
 A: GitVersion won't recognize it and will use default versioning. Always use the correct prefixes: `feature/`, `bugfix/`, `hotfix/`.

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,9 +1,29 @@
 mode: ContinuousDelivery
+
+# Baseline for the next release, needed exactly once to escape the old
+# `v0.1.0-<commit count>` tags: those are pre-release tags, so GitVersion never
+# accepted them as a version source and every release recomputed 0.1.0 forever.
+# The next release ships as 0.2.0 and tags `v0.2.0`, which is a real version
+# source; from then on GitVersion increments from the tag and this line is a
+# no-op floor that can be deleted. It also suppresses the +semver markers below
+# while it is the active baseline.
+next-version: 0.2.0
+
+# Choosing the increment for a release: put one of these in the merge commit
+# message (or the squashed PR title) landing on main. From a 0.2.0 baseline:
+#   +semver: major   (or "breaking")  -> 1.0.0
+#   +semver: minor   (or "feature")   -> 0.3.0
+#   no marker                         -> 0.2.1
+# A marker can only raise the increment above main's `increment:`, never lower
+# it, which is why main is Patch: it keeps all three outcomes reachable. With
+# main on Minor a patch release is impossible — "+semver: patch" is a no-op.
+# So a develop -> main release needs an explicit "+semver: minor"; a hotfix
+# merge needs nothing.
 branches:
   main:
     regex: ^main$
     label: ""
-    increment: Minor
+    increment: Patch
     track-merge-target: false
     is-main-branch: true
   develop:


### PR DESCRIPTION
Every release since `v0.1.0-463` has shipped the same version number. This fixes that, makes major/minor/patch selectable per release, and writes down the release procedure so it can be repeated correctly later.

## The two bugs

**1. The release tag was never a valid version source.** `release-on-merge.yml` tagged from GitVersion's `semVer`, which on `main` renders as `0.1.0-<commit count>` — `main` sets `label: ""` under `mode: ContinuousDelivery`, which drops the label but still appends a numeric pre-release. The `-463` suffix everyone assumed was a PR number is the commit count; it matches `git rev-list --count` exactly for all four tags:

| Tag | `rev-list --count` |
|---|---|
| `v0.1.0-463` | 463 |
| `v0.1.0-466` | 466 |
| `v0.1.0-468` | 468 |
| `v0.1.0-614` | 614 |

Because those are *pre-release* tags, GitVersion refuses them as a version source, so every run recomputed the same `0.0.0` + minor = `0.1.0` baseline. Four releases, one version.

**2. Patch releases were unreachable.** A `+semver:` marker can only raise the increment above the branch's `increment:`, never lower it. With `main` on `increment: Minor`, `+semver: patch` was a silent no-op — contradicting the hotfix workflow CONTRIBUTING already documents.

## Changes

**Versioning fix**
- `release-on-merge.yml` — tag and build from `majorMinorPatch` instead of `semVer`. `majorMinorPatch` is clean on `main`; `semVer` is not. PR previews in `pr-validation.yml` still use `semVer`, which is correct there — feature branches *should* show their `-alpha` suffix.
- `GitVersion.yml` — `next-version: 0.2.0` to escape the stuck baseline once, and `main` moved to `increment: Patch` so all three outcomes are selectable.

**Making it repeatable**
- New `cut-release` skill — the `develop` → `main` procedure end to end.
- `CONTRIBUTING.md` — the `+semver` markers, the raise-only rule, why tags must be plain `vX.Y.Z`, and the two silent steps in a release.
- `pull-request` skill — points at `cut-release`, since release PRs are its one exception to basing on `develop`.

The procedure lives in the skill and the reasoning in CONTRIBUTING, with the skill linking to it, so the two don't drift.

## The two silent failures worth knowing about

Neither shows up as a failed check.

**The increment goes in the PR title.** This repo sets `merge_commit_message: PR_TITLE`, so GitHub copies the PR title into the merge commit body — which is where GitVersion reads the marker. The PR body is not read. So a feature release PR is titled `Release 0.3.0 +semver: minor`.

**The release is a draft.** `release-on-merge.yml` passes `draft: true`. A green workflow does not mean the release shipped; it has to be published (`gh release edit <tag> --draft=false`).

## After merging

The next release ships as `0.2.0` and tags `v0.2.0` — a real version source. From then on:

| Release PR title | Result |
|---|---|
| _(no marker)_ | `0.2.1` |
| `… +semver: minor` | `0.3.0` |
| `… +semver: major` | `1.0.0` |

So a `develop` → `main` release PR needs an explicit `+semver: minor`; a hotfix needs nothing. Once `v0.2.0` exists, `next-version:` is a no-op floor and can be deleted.

## Verification

Workflow changes are not exercised until they run on `main`, so I verified the versioning locally with GitVersion 6.4 (the version `calculate-version.yml` pins) against a throwaway worktree of `origin/main`:

- Reproduced today's behaviour: `main` → `SemVer` `0.1.0-614`, and every `+semver:` marker produced `0.1.0` — confirming the stuck baseline.
- With a clean `v0.1.0` tag as version source and `main` on `increment: Minor`: `+semver: major` → `1.0.0`, but `+semver: patch` → `0.2.0`, confirming markers cannot lower the increment.
- With `main` on `increment: Patch`: no marker → `0.1.1`, `+semver: minor` → `0.2.0`, `+semver: major` → `1.0.0`. All three reachable.
- With this branch's config on a commit past the tag: `MajorMinorPatch` `0.2.0` while `SemVer` was still `0.2.0-1` — the reason for tagging from `majorMinorPatch`.

Merge-commit settings read from the repo API rather than assumed. Doc anchors and the skill's relative links to CONTRIBUTING checked.

Not verified: the actual release run, artifact naming with the new version string, and `generateReleaseNotes` against the new tag. The skill's step 2 is verified only against local GitVersion runs — worth a second look after the first real release proves it out.

## Note on the existing tags

The four `v0.1.0-*` tags are left in place — they are attached to published releases. They do not interfere once `v0.2.0` exists, since a real release tag outranks them. Say the word if you would rather delete them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)