### PR TITLE
Add telemetry record & replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -426,3 +426,6 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+
+# Agent worktrees (transient, created by Claude Code sub-agents)
+.claude/worktrees/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,6 +261,16 @@ public class FuelService : IFuelService, IDisposable
         // Subscribe to events
         telemetry.NewLap += OnNewLap;
         telemetry.SessionPhaseChanged += OnSessionPhaseChanged;
+        telemetry.TelemetryReset += OnTelemetryReset;
+    }
+    
+    // Re-seed accumulated state whenever it becomes invalid. Without this,
+    // oldFuelRemaining survives a session restart or a replay rewind and the
+    // next lap reports nonsense consumption - often negative, after a refuel.
+    private void OnTelemetryReset(TelemetryData data)
+    {
+        oldFuelRemaining = data.Raw.FuelLeft;
+        Data.LastLapFuelUsage = 0;
     }
     
     private void OnNewLap(TelemetryData data)
@@ -287,6 +297,7 @@ public class FuelService : IFuelService, IDisposable
     {
         telemetry.NewLap -= OnNewLap;
         telemetry.SessionPhaseChanged -= OnSessionPhaseChanged;
+        telemetry.TelemetryReset -= OnTelemetryReset;
         GC.SuppressFinalize(this);
     }
 }
@@ -295,6 +306,9 @@ public class FuelService : IFuelService, IDisposable
 **Service Class Rules:**
 - ✅ Depend on `ITelemetryService` and `ITelemetryEventBus`
 - ✅ Subscribe to events in constructor
+- ✅ Reset accumulated state on `TelemetryReset` (see
+  [Core Events](#core-events-from-itelemetryservice)) — widgets have the same
+  hook as `protected override void OnTelemetryReset()`
 - ✅ Create data class instance **once** (store reference)
 - ✅ Update only mutable data fields (not entire object)
 - ✅ Publish cross-feature events via `ITelemetryEventBus`
@@ -322,7 +336,13 @@ Use for session lifecycle events:
   `Action<int>` (the light count), not `Action<TelemetryData>` like every other
   core event
 - `NewLap` - Lap completed
-- `SessionTypeChanged` - Session type changed
+- `TelemetryReset` - **Accumulated state must be discarded.** Raised when the
+  session type changed *or* simulation ticks went backwards (a session restart,
+  RaceRoom's own replay mode, or a replay rewind). Raised before the other
+  per-frame events for that frame. **Any service holding state across frames
+  should reset on this**, not on `SessionTypeChanged`
+- `SessionTypeChanged` - Session type genuinely changed (Practice → Qualify →
+  Race). Nothing else. Use it only when you care about the session *kind*
 - `SessionPhaseChanged` - Session phase changed (Countdown, Formation, Green, etc.)
 - `CarPositionChanged` - Player position changed
 - `TrackChanged` - Track changed
@@ -450,6 +470,29 @@ public class FuelData
 - ✅ Minimal GC pressure
 - ✅ Cache-friendly (same instance)
 - ✅ Always reflects current data
+
+## 🐛 Reproducing Widget Bugs
+
+**A telemetry recording is the preferred way to reproduce a widget bug.** Most
+widget logic is time-dependent — fuel projection, sector deltas, time gaps,
+radar, lap transitions — so a screenshot and a description rarely reproduce
+anything, and test mode only renders static values.
+
+```bash
+# Capture: writes one .yhtl file per session into a timestamped run folder
+YaHud.exe --record-autostart
+
+# Reproduce: replays through the full pipeline, with RaceRoom closed
+YaHud.exe --replay="...\2026-07-25_19-04-spa\03-race.yhtl"
+```
+
+Attach the relevant `.yhtl` file to the issue, and it becomes reproducible on
+any machine — including yours, as often as you need while fixing it. Recording
+is also the practical way to develop a widget without launching the game.
+
+See [Telemetry Recording and Replay](docs/telemetry-recording.md) for the
+options, the file format and the limitations (notably: recordings are tied to
+the exact `Shared` layout, and start lights are only captured on Windows).
 
 ## 🌳 Branching Strategy
 

--- a/R3E.YaHud/Components/Pages/Index.razor
+++ b/R3E.YaHud/Components/Pages/Index.razor
@@ -58,6 +58,9 @@
     <R3E.YaHud.Components.Widget.Radar.Radar />
     <R3E.YaHud.Components.Widget.TvTower.TvTower/>
     <R3E.YaHud.Components.Widget.TireBrakeInfo.TireBrakeInfo />
+    @* Listed unconditionally so it is always registered and therefore always present in the
+       settings panel; it gates its own markup on the recording/replay flags. *@
+    <R3E.YaHud.Components.Widget.RecordReplay.RecordReplay />
 </div>
 
 @if (showSettings)

--- a/R3E.YaHud/Components/UI/Components/Settings/RecordingsCatalog.cs
+++ b/R3E.YaHud/Components/UI/Components/Settings/RecordingsCatalog.cs
@@ -1,0 +1,170 @@
+using R3E.Core.Recording;
+
+namespace R3E.YaHud.Components.UI.Components.Settings
+{
+    /// <summary>
+    /// One <c>.yhtl</c> file in the recordings browser, described by its header alone.
+    /// </summary>
+    /// <param name="Path">Absolute path to the file.</param>
+    /// <param name="FileName">File name, as shown in the list.</param>
+    /// <param name="SizeBytes">Size on disk.</param>
+    /// <param name="Header">The parsed header, or <see langword="null"/> when it could not be read.</param>
+    /// <param name="Error">Why the header could not be read, or <see langword="null"/> when it could.</param>
+    public sealed record RecordingFileEntry(
+        string Path,
+        string FileName,
+        long SizeBytes,
+        TelemetryRecordingHeader? Header,
+        string? Error);
+
+    /// <summary>One recording run folder, holding the session files of a single stint.</summary>
+    /// <param name="Name">Folder name, as shown in the list.</param>
+    /// <param name="Path">Absolute path to the folder.</param>
+    /// <param name="Files">The run's session files, ordered by name.</param>
+    public sealed record RecordingRunEntry(string Name, string Path, IReadOnlyList<RecordingFileEntry> Files);
+
+    /// <summary>
+    /// Everything the browser can only learn by opening the file: the footer summary.
+    /// </summary>
+    /// <param name="Duration">Total recorded duration.</param>
+    /// <param name="TotalFrames">Frame records in the file.</param>
+    /// <param name="MaxNumCars">Highest driver count observed over the whole session.</param>
+    /// <param name="ClassIds">Every car class observed.</param>
+    /// <param name="LapCount">Number of lap-start markers.</param>
+    /// <param name="IndexWasRebuilt">The footer was missing, so the recording was cut short by a crash.</param>
+    public sealed record RecordingDetails(
+        TimeSpan Duration,
+        long TotalFrames,
+        int MaxNumCars,
+        IReadOnlyList<int> ClassIds,
+        int LapCount,
+        bool IndexWasRebuilt);
+
+    /// <summary>
+    /// Enumerates the recordings directory for the settings-panel browser.
+    /// </summary>
+    /// <remarks>
+    /// Listing uses <see cref="TelemetryRecordingHeader.ReadFrom(string)"/>, which is header-only:
+    /// a whole folder can be described without decoding a single block. The footer summary — the
+    /// duration and the observed class set — is only read for the file the user actually selects.
+    /// </remarks>
+    public static class RecordingsCatalog
+    {
+        /// <summary>Name given to the pseudo-run holding files that sit loose in the root.</summary>
+        private const string LooseFilesRunName = "(loose files)";
+
+        /// <summary>
+        /// Scans a recordings root for runs and their session files.
+        /// </summary>
+        /// <param name="root">The recordings directory. It need not exist.</param>
+        /// <returns>The runs found, newest first. Empty when the directory does not exist.</returns>
+        public static IReadOnlyList<RecordingRunEntry> Scan(string root)
+        {
+            if (string.IsNullOrWhiteSpace(root) || !Directory.Exists(root))
+            {
+                return [];
+            }
+
+            var runs = new List<RecordingRunEntry>();
+
+            try
+            {
+                foreach (var folder in Directory.EnumerateDirectories(root).OrderDescending(StringComparer.Ordinal))
+                {
+                    var files = ScanFolder(folder);
+                    if (files.Count > 0)
+                    {
+                        runs.Add(new RecordingRunEntry(Path.GetFileName(folder), folder, files));
+                    }
+                }
+
+                // A --recording-dir pointed straight at a folder of files, or files moved by hand,
+                // should still be listed rather than silently ignored.
+                var loose = ScanFolder(root);
+                if (loose.Count > 0)
+                {
+                    runs.Add(new RecordingRunEntry(LooseFilesRunName, root, loose));
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // A directory that cannot be walked reads as "no recordings" rather than a crashed
+                // settings panel; the browser shows the resolved path so the cause is visible.
+                return runs;
+            }
+
+            return runs;
+        }
+
+        /// <summary>
+        /// Reads the footer summary of a single recording.
+        /// </summary>
+        /// <param name="path">Path to a <c>.yhtl</c> file.</param>
+        /// <param name="details">The summary, when it could be read.</param>
+        /// <param name="error">Why it could not be read, when it could not.</param>
+        /// <returns><see langword="true"/> when <paramref name="details"/> was produced.</returns>
+        public static bool TryReadDetails(string path, out RecordingDetails? details, out string? error)
+        {
+            details = null;
+            error = null;
+
+            try
+            {
+                using var reader = new TelemetryRecordingReader(path);
+                details = new RecordingDetails(
+                    reader.Duration,
+                    reader.TotalFrames,
+                    reader.MaxNumCars,
+                    reader.ClassIds,
+                    reader.Markers.Count(m => m.Type == RecordingMarkerType.LapStart),
+                    reader.IndexWasRebuilt);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+                return false;
+            }
+        }
+
+        private static List<RecordingFileEntry> ScanFolder(string folder)
+        {
+            var files = new List<RecordingFileEntry>();
+
+            foreach (var path in Directory
+                .EnumerateFiles(folder, "*" + TelemetryRecordingHeader.FileExtension)
+                .Order(StringComparer.Ordinal))
+            {
+                files.Add(Describe(path));
+            }
+
+            return files;
+        }
+
+        private static RecordingFileEntry Describe(string path)
+        {
+            var name = Path.GetFileName(path);
+            long size = 0;
+
+            try
+            {
+                size = new FileInfo(path).Length;
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // Size is cosmetic; a locked file still gets a row.
+            }
+
+            try
+            {
+                return new RecordingFileEntry(path, name, size, TelemetryRecordingHeader.ReadFrom(path), null);
+            }
+            catch (Exception ex)
+            {
+                // A version mismatch throws with a message written to be shown to a user. Surface it
+                // on the row rather than letting it take the panel down.
+                return new RecordingFileEntry(path, name, size, null, ex.Message);
+            }
+        }
+    }
+}

--- a/R3E.YaHud/Components/UI/Components/Settings/Settings.razor
+++ b/R3E.YaHud/Components/UI/Components/Settings/Settings.razor
@@ -12,7 +12,10 @@
                 <SettingsMasterPanel OnClose="OnClose" Widgets="Widgets" />
             </CascadingValue>
 
-            @if (SettingsContext.SelectedWidget is not null) {
+            @if (SettingsContext.RecordingsSelected) {
+                <SettingsRecordingsPanel OnClose="OnClose" />
+            }
+            else if (SettingsContext.SelectedWidget is not null) {
                 <SettingsDetailPanel Widget="SettingsContext.SelectedWidget" />
             }
         </CascadingValue>
@@ -30,7 +33,15 @@
 
     private void OpenDetailsForWidget(IWidget widget)
     {
+        SettingsContext.RecordingsSelected = false;
         SettingsContext.SelectedWidget = widget;
+        InvokeAsync(StateHasChanged);
+    }
+
+    private void OpenRecordings()
+    {
+        SettingsContext.SelectedWidget = null;
+        SettingsContext.RecordingsSelected = true;
         InvokeAsync(StateHasChanged);
     }
 
@@ -40,7 +51,8 @@
 
         SettingsContext = new()
             {
-                OpenDetails = OpenDetailsForWidget
+                OpenDetails = OpenDetailsForWidget,
+                OpenRecordings = OpenRecordings
             };
     }
 

--- a/R3E.YaHud/Components/UI/Components/Settings/SettingsContext.cs
+++ b/R3E.YaHud/Components/UI/Components/Settings/SettingsContext.cs
@@ -1,4 +1,4 @@
-﻿using R3E.YaHud.Components.Widget.Core;
+using R3E.YaHud.Components.Widget.Core;
 
 namespace R3E.YaHud.Components.UI.Components.Settings
 {
@@ -6,5 +6,11 @@ namespace R3E.YaHud.Components.UI.Components.Settings
     {
         public Action<IWidget>? OpenDetails { get; set; }
         public IWidget? SelectedWidget { get; set; }
+
+        /// <summary>Opens the recordings browser in the detail area.</summary>
+        public Action? OpenRecordings { get; set; }
+
+        /// <summary>Whether the detail area is showing the recordings browser rather than a widget.</summary>
+        public bool RecordingsSelected { get; set; }
     }
 }

--- a/R3E.YaHud/Components/UI/Components/Settings/SettingsMasterPanel.razor
+++ b/R3E.YaHud/Components/UI/Components/Settings/SettingsMasterPanel.razor
@@ -11,6 +11,16 @@
     </div>
 
     <div class="panel-body">
+        <div class="category-container">
+            <h3 class="category-title">Telemetry Recordings</h3>
+            <ul class="category-widgets">
+                <li class="widget-item @(SettingsContext.RecordingsSelected ? "selected" : "")" @onclick="() => SettingsContext.OpenRecordings!()">
+                    <div class="select-effect"></div>
+                    <h4 class="widget-name">Browse Recordings</h4>
+                </li>
+            </ul>
+        </div>
+
         @foreach (var group in WidgetsByCategory)
         {
             <SettingsCategory Name="@group.Key" Widgets="@group.AsEnumerable()" />
@@ -28,6 +38,9 @@
 
     [CascadingParameter]
     public SettingPanelEvents Events { get; set; } = default!;
+
+    [CascadingParameter]
+    public SettingsContext SettingsContext { get; set; } = null!;
 
     private IEnumerable<IGrouping<string, IWidget>> WidgetsByCategory => Widgets.GroupBy(w => w.Category);
 }

--- a/R3E.YaHud/Components/UI/Components/Settings/SettingsMasterPanel.razor.css
+++ b/R3E.YaHud/Components/UI/Components/Settings/SettingsMasterPanel.razor.css
@@ -11,3 +11,50 @@
     background-color: #57606f;
     background-size: 64px 128px;
 }
+
+/* The recordings entry is not a widget, so it cannot go through SettingsCategory; these mirror
+   that component's list styling so it reads as one more row in the same list. */
+.settings-master .category-container {
+    display: flex;
+    flex-direction: column;
+}
+
+.settings-master .category-title {
+    background: linear-gradient(90deg, rgba(131, 144, 166, 1) 0%, rgba(87, 96, 111, 1) 100%);
+    position: sticky;
+    top: 0;
+    padding: 0.5rem 1rem;
+    font-size: 1.55rem;
+    font-weight: bold;
+    z-index: 10;
+}
+
+.settings-master .category-widgets {
+    padding: 0 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.settings-master .widget-item {
+    background: #747d8c;
+    border-radius: 0.25rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.75rem;
+    position: relative;
+    cursor: pointer;
+}
+
+.settings-master .widget-item.selected,
+.settings-master .widget-item:hover {
+    background: #7f8899;
+}
+
+.settings-master .widget-item .widget-name {
+    margin: 0;
+    margin-right: auto;
+    font-size: 1rem;
+    z-index: 5;
+}

--- a/R3E.YaHud/Components/UI/Components/Settings/SettingsRecordingsPanel.razor
+++ b/R3E.YaHud/Components/UI/Components/Settings/SettingsRecordingsPanel.razor
@@ -1,0 +1,252 @@
+@using R3E.Core.Recording
+@using R3E.Core.Replay
+@using R3E.Data
+@inject RecordingOptions RecordingOptions
+@inject ReplayController ReplayController
+
+<div class="settings-panel settings-recordings" @onclick="() => Events.RaiseBodyClick()" @onclick:stopPropagation>
+    <div class="panel-header">
+        <h2>Recordings</h2>
+        <button class="btn dark" @onclick="Refresh">Refresh</button>
+    </div>
+
+    <div class="panel-body">
+        <p class="root-path">@root</p>
+
+        @if (loadError is not null)
+        {
+            <p class="load-error">@loadError</p>
+        }
+
+        @if (runs.Count == 0)
+        {
+            <p class="empty">
+                No recordings yet. Launch YaHud with <code>--record</code> and press Record on the
+                Record &amp; Replay widget; files appear here once the first telemetry frame arrives.
+            </p>
+        }
+
+        @foreach (var run in runs)
+        {
+            <div class="run">
+                <h3 class="run-title">@run.Name</h3>
+                <ul class="run-files">
+                    @foreach (var file in run.Files)
+                    {
+                        <li class="recording @(selected?.Path == file.Path ? "selected" : "") @(file.Header is null ? "broken" : "")"
+                            @onclick="() => Select(file)">
+                            <div class="recording-head">
+                                <span class="recording-name">@file.FileName</span>
+                                <span class="recording-size">@FormatBytes(file.SizeBytes)</span>
+                            </div>
+
+                            @if (file.Header is null)
+                            {
+                                <div class="recording-error">@file.Error</div>
+                            }
+                            else
+                            {
+                                <div class="recording-meta">
+                                    <span>@SessionName(file.Header.SessionType)</span>
+                                    <span>@TrackLabel(file.Header)</span>
+                                    <span>@file.Header.NumCarsAtStart drivers</span>
+                                    <span>@file.Header.StartUtc.ToLocalTime().ToString("g")</span>
+                                </div>
+                                <div class="recording-meta subtle">
+                                    <span>@file.Header.PlayerName</span>
+                                    <span>car @file.Header.PlayerCarModelId</span>
+                                    <span>class @file.Header.PlayerClassId</span>
+                                </div>
+                            }
+
+                            @if (selected?.Path == file.Path)
+                            {
+                                <div class="recording-detail">
+                                    @if (detailsError is not null)
+                                    {
+                                        <span class="recording-error">@detailsError</span>
+                                    }
+                                    else if (details is not null)
+                                    {
+                                        <span>@FormatDuration(details.Duration)</span>
+                                        <span>@details.TotalFrames frames</span>
+                                        <span>@details.LapCount laps</span>
+                                        <span>up to @details.MaxNumCars drivers</span>
+                                        <span>@details.ClassIds.Count classes</span>
+                                        @if (details.IndexWasRebuilt)
+                                        {
+                                            <span class="warn">index rebuilt - recording was cut short</span>
+                                        }
+                                    }
+
+                                    <button class="btn dark"
+                                            disabled="@(busy || file.Header is null)"
+                                            @onclick="() => Load(file)"
+                                            @onclick:stopPropagation>
+                                        @(busy ? "Loading…" : "Replay")
+                                    </button>
+                                </div>
+                            }
+                        </li>
+                    }
+                </ul>
+            </div>
+        }
+    </div>
+
+    <div class="panel-footer">
+        @if (ReplayController.IsLoaded)
+        {
+            <span class="loaded">Replaying @System.IO.Path.GetFileName(ReplayController.CurrentFile)</span>
+            <button class="btn dark danger-hover" disabled="@busy" @onclick="ReturnToLive">Return to Live</button>
+        }
+        else
+        {
+            <span class="loaded">Live telemetry</span>
+        }
+    </div>
+</div>
+
+@code {
+    [Parameter] public EventCallback OnClose { get; set; }
+
+    [CascadingParameter] public SettingPanelEvents Events { get; set; } = default!;
+
+    private string root = string.Empty;
+    private IReadOnlyList<RecordingRunEntry> runs = [];
+    private RecordingFileEntry? selected;
+    private RecordingDetails? details;
+    private string? detailsError;
+    private string? loadError;
+    private bool busy;
+
+    protected override void OnInitialized()
+    {
+        root = RecordingOptions.ResolveDirectory();
+        Refresh();
+    }
+
+    private void Refresh()
+    {
+        runs = RecordingsCatalog.Scan(root);
+        selected = null;
+        details = null;
+        detailsError = null;
+    }
+
+    /// <summary>
+    /// Selects a row and reads its footer summary. Header metadata is already in hand from the
+    /// listing; only the selected file is opened.
+    /// </summary>
+    private void Select(RecordingFileEntry file)
+    {
+        if (selected?.Path == file.Path)
+        {
+            selected = null;
+            details = null;
+            detailsError = null;
+            return;
+        }
+
+        selected = file;
+        details = null;
+        detailsError = null;
+
+        if (file.Header is null)
+        {
+            detailsError = file.Error;
+            return;
+        }
+
+        if (!RecordingsCatalog.TryReadDetails(file.Path, out details, out detailsError))
+        {
+            details = null;
+        }
+    }
+
+    /// <summary>
+    /// Activates replay on the selected recording, then closes the overlay so the transport widget
+    /// is reachable.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="ReplayController.Load"/> stops and joins the replay pump thread, so it is pushed
+    /// off the Blazor dispatcher rather than blocking the whole UI while that happens.
+    /// </remarks>
+    private async Task Load(RecordingFileEntry file)
+    {
+        if (busy || file.Header is null)
+        {
+            return;
+        }
+
+        busy = true;
+        loadError = null;
+
+        try
+        {
+            await Task.Run(() => ReplayController.Load(file.Path));
+            await OnClose.InvokeAsync();
+        }
+        catch (Exception ex)
+        {
+            loadError = ex.Message;
+        }
+        finally
+        {
+            busy = false;
+        }
+    }
+
+    private async Task ReturnToLive()
+    {
+        if (busy)
+        {
+            return;
+        }
+
+        busy = true;
+
+        try
+        {
+            await Task.Run(ReplayController.Unload);
+        }
+        catch (Exception ex)
+        {
+            loadError = ex.Message;
+        }
+        finally
+        {
+            busy = false;
+        }
+    }
+
+    private static string SessionName(int sessionType)
+        => Enum.IsDefined(typeof(Constant.Session), sessionType)
+            ? ((Constant.Session)sessionType).ToString()
+            : $"Session {sessionType}";
+
+    private static string TrackLabel(TelemetryRecordingHeader header)
+        => string.IsNullOrWhiteSpace(header.LayoutName) || header.LayoutName == header.TrackName
+            ? header.TrackName
+            : $"{header.TrackName} - {header.LayoutName}";
+
+    private static string FormatDuration(TimeSpan value)
+        => value.TotalHours >= 1 ? value.ToString(@"h\:mm\:ss") : value.ToString(@"mm\:ss");
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024)
+        {
+            return $"{bytes} B";
+        }
+
+        if (bytes < 1024 * 1024)
+        {
+            return $"{bytes / 1024d:F1} KB";
+        }
+
+        return bytes < 1024L * 1024 * 1024
+            ? $"{bytes / (1024d * 1024d):F1} MB"
+            : $"{bytes / (1024d * 1024d * 1024d):F2} GB";
+    }
+}

--- a/R3E.YaHud/Components/UI/Components/Settings/SettingsRecordingsPanel.razor.css
+++ b/R3E.YaHud/Components/UI/Components/Settings/SettingsRecordingsPanel.razor.css
@@ -1,0 +1,146 @@
+.settings-recordings {
+    grid-area: detail;
+
+    .panel-body {
+        background: linear-gradient(135deg, #57606f 21px, #5e6677 22px, #5e6677 24px, transparent 24px, transparent 67px, #5e6677 67px, #5e6677 69px, transparent 69px), linear-gradient(225deg, #57606f 21px, #5e6677 22px, #5e6677 24px, transparent 24px, transparent 67px, #5e6677 67px, #5e6677 69px, transparent 69px) 0 64px;
+        background-color: #57606f;
+        background-size: 64px 128px;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+
+        &::-webkit-scrollbar {
+            width: 10px;
+        }
+
+        &::-webkit-scrollbar-thumb {
+            background: rgba(255,255,255,0.1);
+            border-radius: 10px;
+        }
+    }
+
+    .root-path {
+        margin: 0;
+        font-size: 0.8rem;
+        opacity: 0.7;
+        overflow-wrap: anywhere;
+    }
+
+    .empty {
+        margin: 0;
+        padding: 1rem;
+        background: rgba(255 255 255 / 0.05);
+        border-radius: 0.5rem;
+        font-size: 0.9rem;
+    }
+
+    .load-error {
+        margin: 0;
+        padding: 0.75rem 1rem;
+        background: rgba(255 59 48 / 0.2);
+        border-radius: 0.5rem;
+        font-size: 0.85rem;
+    }
+
+    .run {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .run-title {
+        margin: 0;
+        font-size: 1rem;
+        padding-bottom: 0.25rem;
+        border-bottom: 1px solid rgba(255 255 255 / 0.2);
+    }
+
+    .run-files {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .recording {
+        background: rgba(255 255 255 / 0.05);
+        border-radius: 0.5rem;
+        padding: 0.75rem;
+        cursor: pointer;
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+
+        &:hover {
+            background: rgba(255 255 255 / 0.1);
+        }
+
+        &.selected {
+            background: rgba(255 255 255 / 0.14);
+            outline: 1px solid rgba(255 255 255 / 0.35);
+        }
+
+        &.broken {
+            background: rgba(255 59 48 / 0.15);
+        }
+    }
+
+    .recording-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 1rem;
+    }
+
+    .recording-name {
+        font-weight: 700;
+    }
+
+    .recording-size {
+        opacity: 0.7;
+        font-size: 0.85rem;
+    }
+
+    .recording-meta {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem 1rem;
+        font-size: 0.85rem;
+
+        &.subtle {
+            opacity: 0.6;
+            font-size: 0.75rem;
+        }
+    }
+
+    .recording-error {
+        font-size: 0.8rem;
+        overflow-wrap: anywhere;
+    }
+
+    .recording-detail {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.25rem 1rem;
+        font-size: 0.85rem;
+        padding-top: 0.5rem;
+        border-top: 1px solid rgba(255 255 255 / 0.2);
+
+        .warn {
+            color: #ffb020;
+        }
+
+        .btn {
+            margin-left: auto;
+        }
+    }
+
+    .panel-footer .loaded {
+        margin-right: auto;
+        align-self: center;
+        font-size: 0.85rem;
+    }
+}

--- a/R3E.YaHud/Components/UI/Components/Settings/SettingsWidgetMenu.razor
+++ b/R3E.YaHud/Components/UI/Components/Settings/SettingsWidgetMenu.razor
@@ -11,7 +11,12 @@
     {
         <div id="@MenuId" class="widget-menu">
             <ul>
-                <li class="menu-item" @onclick="() => { Widget.ResetPosition(); ToggleMenu(); }">Reset Position</li>
+                @* A docked widget is placed by its own CSS, so there is no position to reset.
+                   Scale still applies. *@
+                @if (!Widget.Docked)
+                {
+                    <li class="menu-item" @onclick="() => { Widget.ResetPosition(); ToggleMenu(); }">Reset Position</li>
+                }
                 <li class="menu-item" @onclick="() => { Widget.ResetScale(); ToggleMenu(); }">Reset Scale</li>
             </ul>
         </div>

--- a/R3E.YaHud/Components/Widget/Core/BasicSettings.cs
+++ b/R3E.YaHud/Components/Widget/Core/BasicSettings.cs
@@ -28,6 +28,24 @@ namespace R3E.YaHud.Components.Widget.Core
 
         public double Scale { get; set; } = 1.0;
 
+        /// <summary>
+        /// Whether this widget is pinned in place by its own CSS rather than positioned from
+        /// <see cref="XPercent"/>/<see cref="YPercent"/>. Settings classes that expose a dock
+        /// setting override this; everything else stays free.
+        /// </summary>
+        /// <remarks>
+        /// It lives on the settings rather than on the widget so it can flip at runtime from a
+        /// single settings change, and so <see cref="IsPositionSettingVisible"/> can be used as a
+        /// <see cref="SettingTypeAttribute.VisibilityPredicateName"/> without any widget plumbing.
+        /// </remarks>
+        public virtual bool Docked => false;
+
+        /// <summary>
+        /// Visibility predicate for settings that only mean something when the widget can be moved.
+        /// Scale is deliberately not covered: a docked widget still scales.
+        /// </summary>
+        public bool IsPositionSettingVisible() => !Docked;
+
         public event PropertyChangedEventHandler? PropertyChanged;
 
 

--- a/R3E.YaHud/Components/Widget/Core/HudWidgetBase.cs
+++ b/R3E.YaHud/Components/Widget/Core/HudWidgetBase.cs
@@ -32,6 +32,24 @@ namespace R3E.YaHud.Components.Widget.Core
 
         public abstract bool Collidable { get; }
 
+        /// <summary>
+        /// Whether the widget is pinned in place by its own CSS instead of by
+        /// <see cref="BasicSettings.XPercent"/>/<see cref="BasicSettings.YPercent"/>.
+        /// </summary>
+        /// <remarks>
+        /// A docked widget gets no drag listener, which is the point: with nothing native listening
+        /// for <c>mousedown</c> on the host, controls inside the widget keep working while the HUD
+        /// is unlocked. It also takes no part in collision or snapping, and its position settings are
+        /// meaningless. Scale is unaffected. Derived from the settings so it can flip at runtime.
+        /// </remarks>
+        public bool Docked => Settings?.Docked ?? false;
+
+        /// <summary>
+        /// Transform origin a docked widget is scaled about, so growing the scale never pushes the
+        /// widget off the edge it is pinned to. Defaults to the free-widget origin.
+        /// </summary>
+        protected virtual string DockedTransformOrigin => "top left";
+
         BasicSettings? IWidget.Settings => Settings;
 
         public TSettings? Settings { get; set; }
@@ -43,6 +61,7 @@ namespace R3E.YaHud.Components.Widget.Core
         private DateTime lastUpdate = DateTime.MinValue;
         private bool initializedTransformations = false;
         private bool registeredTransformations = false;
+        private bool? appliedDocked;
 
         protected virtual void Update() { }
 
@@ -115,6 +134,16 @@ namespace R3E.YaHud.Components.Widget.Core
                 return;
             }
 
+            // Docking can be switched from the settings panel, so both the registration (which
+            // decides whether a drag listener exists) and the placement have to be redone when it
+            // changes - not just once on first render.
+            var docked = Docked;
+            if (appliedDocked != docked)
+            {
+                registeredTransformations = false;
+                initializedTransformations = false;
+            }
+
             if (!registeredTransformations)
             {
                 registeredTransformations = true;
@@ -127,7 +156,10 @@ namespace R3E.YaHud.Components.Widget.Core
                         ElementId,
                         objRef,
                         Locked,
-                        Collidable
+                        // Docked widgets are placed by CSS and never move, so they cannot collide
+                        // with anything or be snapped away from their edge.
+                        Collidable && !docked,
+                        !docked
                     );
 
                 }
@@ -140,18 +172,29 @@ namespace R3E.YaHud.Components.Widget.Core
             if (ElementRef.Context is not null && !initializedTransformations)
             {
                 initializedTransformations = true;
+                appliedDocked = docked;
+
                 await JS.InvokeVoidAsync(
                     "HudHelper.setScale",
                     ElementId,
                     Settings.Scale
                 );
 
-                await JS.InvokeVoidAsync(
-                    "HudHelper.setPosition",
-                    ElementId,
-                    Settings.XPercent,
-                    Settings.YPercent
-                );
+                if (docked)
+                {
+                    // Drops whatever inline placement a previous free position (or drag) left on the
+                    // element, so the docking rules in the stylesheet are what actually applies.
+                    await JS.InvokeVoidAsync("HudHelper.dockElement", ElementId, DockedTransformOrigin);
+                }
+                else
+                {
+                    await JS.InvokeVoidAsync(
+                        "HudHelper.setPosition",
+                        ElementId,
+                        Settings.XPercent,
+                        Settings.YPercent
+                    );
+                }
 
                 await JS.InvokeVoidAsync("HudHelper.enableTransformation", ElementId);
             }
@@ -243,6 +286,10 @@ namespace R3E.YaHud.Components.Widget.Core
 
         public async Task ResetPosition()
         {
+            // The menu hides this for docked widgets; the guard keeps a stray call from stamping an
+            // inline position onto an element the stylesheet is placing.
+            if (Docked) return;
+
             objRef ??= DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("HudHelper.resetPosition", ElementId, objRef, DefaultXPercent, DefaultYPercent);
         }
@@ -369,6 +416,10 @@ namespace R3E.YaHud.Components.Widget.Core
                     Logger?.LogDebug("OnWindowResize called on disposed component or with null settings");
                     return;
                 }
+
+                // A docked widget follows the viewport through CSS; re-stamping a percentage
+                // position would tear it off its edge.
+                if (Docked) return;
 
                 await JS.InvokeVoidAsync("HudHelper.setPosition", ElementId, Settings.XPercent, Settings.YPercent);
             }

--- a/R3E.YaHud/Components/Widget/Core/HudWidgetBase.cs
+++ b/R3E.YaHud/Components/Widget/Core/HudWidgetBase.cs
@@ -66,7 +66,33 @@ namespace R3E.YaHud.Components.Widget.Core
             SettingsService.RegisterWidget(this);
             LockService.OnLockChanged += OnLockChanged;
             TestModeService.OnTestModeChanged += OnTestModeChanged;
-            if (UseR3EData) TelemetryService.DataUpdated += OnTelemetryDataUpdated;
+            if (UseR3EData)
+            {
+                TelemetryService.DataUpdated += OnTelemetryDataUpdated;
+                TelemetryService.TelemetryReset += OnTelemetryResetRaised;
+            }
+        }
+
+        /// <summary>
+        /// Called when accumulated telemetry state becomes invalid - session change, session
+        /// restart, RaceRoom replay, or a rewound stream. Only widgets that keep their own history
+        /// across frames need to override; everything derived from a feature service is reset by
+        /// that service. Raised on the telemetry thread, so marshal any render onto the dispatcher.
+        /// </summary>
+        protected virtual void OnTelemetryReset() { }
+
+        private void OnTelemetryResetRaised(TelemetryData data)
+        {
+            try
+            {
+                OnTelemetryReset();
+            }
+            catch (Exception ex)
+            {
+                // A throwing widget must not break the reset for the widgets after it in the
+                // invocation list, nor fault the telemetry thread.
+                Logger.LogError(ex, "Error resetting widget {ElementId}", ElementId);
+            }
         }
 
         protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -379,6 +405,7 @@ namespace R3E.YaHud.Components.Widget.Core
             LockService.OnLockChanged -= OnLockChanged;
             TestModeService.OnTestModeChanged -= OnTestModeChanged;
             TelemetryService.DataUpdated -= OnTelemetryDataUpdated;
+            TelemetryService.TelemetryReset -= OnTelemetryResetRaised;
             objRef?.Dispose();
             GC.SuppressFinalize(this);
         }

--- a/R3E.YaHud/Components/Widget/Core/IWidget.cs
+++ b/R3E.YaHud/Components/Widget/Core/IWidget.cs
@@ -9,6 +9,12 @@ namespace R3E.YaHud.Components.Widget.Core
         public string ElementId { get; }
         public ElementReference ElementRef { get; set; }
 
+        /// <summary>
+        /// Whether the widget is pinned in place by its own CSS. Docked widgets cannot be dragged
+        /// or repositioned, so the settings UI hides everything that only applies to a free widget.
+        /// </summary>
+        public bool Docked { get; }
+
         public BasicSettings? Settings { get; }
         public Type GetSettingsType();
 

--- a/R3E.YaHud/Components/Widget/Core/WidgetDockSide.cs
+++ b/R3E.YaHud/Components/Widget/Core/WidgetDockSide.cs
@@ -1,0 +1,31 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace R3E.YaHud.Components.Widget.Core
+{
+    /// <summary>
+    /// Where a widget is pinned to the screen. Anything other than <see cref="Free"/> makes the
+    /// widget <em>docked</em>: it is placed by its own stylesheet instead of by
+    /// <see cref="BasicSettings.XPercent"/>/<see cref="BasicSettings.YPercent"/>, it takes no drag
+    /// handler, and it therefore keeps its controls usable while the HUD is unlocked.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately a shared enum rather than a per-widget one: the edge rails here and the planned
+    /// full-width position bar are the same concept seen from two sides, and a common enum keeps the
+    /// host CSS classes (<c>dock-left</c>, <c>dock-right</c>, …) and the visibility predicate in one
+    /// place.
+    /// </remarks>
+    public enum WidgetDockSide
+    {
+        /// <summary>Not docked: freely draggable and positioned by percentage, as widgets always were.</summary>
+        [Display(Name = "Free")]
+        Free,
+
+        /// <summary>Pinned to the left screen edge, vertically centred.</summary>
+        [Display(Name = "Left")]
+        Left,
+
+        /// <summary>Pinned to the right screen edge, vertically centred.</summary>
+        [Display(Name = "Right")]
+        Right
+    }
+}

--- a/R3E.YaHud/Components/Widget/Core/WidgetHost.razor.css
+++ b/R3E.YaHud/Components/Widget/Core/WidgetHost.razor.css
@@ -5,3 +5,30 @@
     pointer-events: auto;
     box-sizing: border-box;
 }
+
+/* Docked widgets are pinned to a screen edge by these rules instead of by the inline left/top
+   HudHelper.setPosition writes for free widgets - HudHelper.dockElement clears that inline
+   placement so these can take effect. They register no drag handler, which is what keeps their
+   controls usable while the HUD is unlocked.
+
+   Vertical centring is left to the widget's own content (a translateY(-50%) on the inner box)
+   rather than done here, because the host's transform belongs to HudHelper.setScale. Scaling about
+   the top edge keeps the content centred on the 50% line at any scale. */
+.widget-host.docked {
+    position: fixed;
+    top: 50%;
+    /* A docked host is sized to its expanded content even while collapsed, so it must not sit there
+       as an invisible strip swallowing clicks along the screen edge. The parts that should take the
+       pointer opt back in. */
+    pointer-events: none;
+}
+
+.widget-host.dock-left {
+    left: 0;
+    right: auto;
+}
+
+.widget-host.dock-right {
+    right: 0;
+    left: auto;
+}

--- a/R3E.YaHud/Components/Widget/RecordReplay/RecordReplay.razor
+++ b/R3E.YaHud/Components/Widget/RecordReplay/RecordReplay.razor
@@ -30,7 +30,7 @@
                 else if (ReplayController.IsLoaded)
                 {
                     <span class="rail-glyph" style="color: @Settings!.ReplayColor">@(ReplayController.IsPlaying ? "▶" : "‖")</span>
-                    <span class="rail-text" style="color: @Settings!.ReplayColor">@FormatDuration(DisplayPosition)</span>
+                    <span class="rail-text" style="color: @Settings!.ReplayColor">@FormatDuration(ReplayController.Position)</span>
                 }
                 else
                 {
@@ -92,15 +92,18 @@
                     </div>
 
                     <div class="timeline">
-                        <span class="time" style="color: @Settings!.LabelColor">@FormatDuration(DisplayPosition)</span>
+                        @* Deliberately no reactive @FormatDuration(...) binding here: JS
+                           (HudHelper.bindScrubber) owns this label's text and the input's value
+                           exclusively after the first render, so a live-playing position never
+                           fights a user's in-progress drag. See the remarks on OnScrubCommit. *@
+                        <span id="@ScrubberLabelElementId" class="time" style="color: @Settings!.LabelColor"></span>
                         <div class="scrub">
-                            <input class="scrubber"
+                            <input id="@ScrubberElementId"
+                                   class="scrubber"
                                    type="range"
                                    min="0"
                                    max="@ToInvariant(DurationSeconds)"
                                    step="0.05"
-                                   value="@ToInvariant(SliderSeconds)"
-                                   @oninput="OnScrubInput"
                                    @onchange="OnScrubCommit" />
                             @if (ReplayController.IsCatchingUp)
                             {
@@ -153,18 +156,11 @@
     /// <summary>Playback rates offered by the speed picker.</summary>
     private static readonly double[] SpeedPresets = [0.1, 0.25, 0.5, 1, 2, 4, 8];
 
-    /// <summary>
-    /// How long the scrubber may sit still mid-drag before the position is committed. Dragging
-    /// itself never seeks: acting on every drag tick would fire a reset per pixel travelled on a
-    /// backward drag, each restarting playback from file start.
-    /// </summary>
-    private static readonly TimeSpan ScrubCommitDelay = TimeSpan.FromMilliseconds(150);
-
     private TelemetryRecorder? recorder;
-    private System.Timers.Timer? scrubTimer;
-    private double? scrubPreviewSeconds;
 
     public override string ElementId => "RecordReplayWidget";
+    private string ScrubberElementId => $"{ElementId}-scrubber";
+    private string ScrubberLabelElementId => $"{ElementId}-scrub-time";
     public override string Name => "Record & Replay";
     public override string Category => "Tools";
     public override double DefaultXPercent => 50;
@@ -215,13 +211,6 @@
     }
 
     private double DurationSeconds => Math.Max(0.05, ReplayController.Duration.TotalSeconds);
-
-    /// <summary>Position shown in the readout: the drag preview while scrubbing, else the real one.</summary>
-    private TimeSpan DisplayPosition => scrubPreviewSeconds is { } preview
-        ? TimeSpan.FromSeconds(preview)
-        : ReplayController.Position;
-
-    private double SliderSeconds => scrubPreviewSeconds ?? ReplayController.Position.TotalSeconds;
 
     private int CurrentLap => TelemetryService.Data.Raw.CompletedLaps + 1;
 
@@ -302,29 +291,36 @@
     private void StopReplay() => ReplayController.Unload();
 
     /// <summary>
-    /// Records the drag position without seeking. The scrubber is therefore never hard-locked, even
-    /// mid-catch-up.
+    /// Commits the drag on release - the only point this widget ever seeks from. The pump
+    /// supersedes any in-flight seek by itself.
     /// </summary>
-    private void OnScrubInput(ChangeEventArgs e)
-    {
-        if (!TryReadSeconds(e, out var seconds))
-        {
-            return;
-        }
-
-        scrubPreviewSeconds = seconds;
-        RestartScrubTimer();
-    }
-
-    /// <summary>Commits the drag on release. The pump supersedes any in-flight seek by itself.</summary>
+    /// <remarks>
+    /// <para>
+    /// There is deliberately no <c>@@oninput</c> handler reaching into C#. A native range input
+    /// fires <c>input</c> on every pixel of a drag; over a Blazor Server circuit each one is a
+    /// SignalR round trip, and under any circuit load (the replay pump's own frequent re-renders,
+    /// for instance) those can queue and keep arriving well after release. A previous version used
+    /// <c>@@oninput</c> to drive a live preview and a commit-on-stillness timer - both of which kept
+    /// being re-triggered by that backlog long after the user let go, each stale commit forcing a
+    /// fresh rewind-to-start before the previous catch-up could finish. That read as the replay
+    /// resetting to the start over and over.
+    /// </para>
+    /// <para>
+    /// The live preview during the drag itself (the scrubber's own thumb position, and the
+    /// adjacent time label) is now owned entirely by <c>HudHelper.bindScrubber</c> in JS - see
+    /// <see cref="OnAfterRenderAsync"/>. That also closes a second, related fight: with the input's
+    /// <c>value</c> bound reactively in Razor, a still-playing replay's position kept getting
+    /// re-rendered into the DOM every ~100ms, yanking the slider back to the live position mid-drag
+    /// regardless of which direction the user dragged. JS now only pushes a new value while the
+    /// user is not actively holding the slider.
+    /// </para>
+    /// </remarks>
     private void OnScrubCommit(ChangeEventArgs e)
     {
         if (TryReadSeconds(e, out var seconds))
         {
-            scrubPreviewSeconds = seconds;
+            ReplayController.Seek(TimeSpan.FromSeconds(seconds));
         }
-
-        CommitScrub();
     }
 
     private void OnSpeedChanged(ChangeEventArgs e)
@@ -347,48 +343,22 @@
         => double.TryParse(e.Value?.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out seconds);
 
     /// <summary>
-    /// Restarts the stillness timer, so a drag that stops without a release event still commits.
+    /// Binds the scrubber's live-drag preview once, then pushes the current position into it every
+    /// render - JS applies the push only while the user is not actively dragging (see the remarks on
+    /// <see cref="OnScrubCommit"/>).
     /// </summary>
-    private void RestartScrubTimer()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        scrubTimer ??= CreateScrubTimer();
-        scrubTimer.Stop();
-        scrubTimer.Start();
-    }
+        await base.OnAfterRenderAsync(firstRender);
 
-    private System.Timers.Timer CreateScrubTimer()
-    {
-        var timer = new System.Timers.Timer(ScrubCommitDelay.TotalMilliseconds) { AutoReset = false };
-        timer.Elapsed += (_, _) =>
-        {
-            if (disposed)
-            {
-                return;
-            }
-
-            // Routed through the dispatcher rather than seeking straight from the timer thread, so
-            // every seek this widget issues is raised from the same place.
-            _ = InvokeAsync(() =>
-            {
-                CommitScrub();
-                StateHasChanged();
-            });
-        };
-
-        return timer;
-    }
-
-    private void CommitScrub()
-    {
-        scrubTimer?.Stop();
-
-        if (scrubPreviewSeconds is not { } seconds)
+        if (!ReplayController.IsLoaded)
         {
             return;
         }
 
-        scrubPreviewSeconds = null;
-        ReplayController.Seek(TimeSpan.FromSeconds(seconds));
+        await JS.InvokeVoidAsync("HudHelper.bindScrubber", ScrubberElementId, ScrubberLabelElementId);
+        await JS.InvokeVoidAsync(
+            "HudHelper.setScrubberValueIfIdle", ScrubberElementId, ReplayController.Position.TotalSeconds, ScrubberLabelElementId);
     }
 
     /// <summary>Nothing to show: this widget renders no telemetry.</summary>
@@ -424,10 +394,6 @@
         }
 
         ReplayController.StateChanged -= OnSourceStateChanged;
-
-        scrubTimer?.Stop();
-        scrubTimer?.Dispose();
-        scrubTimer = null;
 
         base.Dispose();
     }

--- a/R3E.YaHud/Components/Widget/RecordReplay/RecordReplay.razor
+++ b/R3E.YaHud/Components/Widget/RecordReplay/RecordReplay.razor
@@ -11,12 +11,36 @@
 
 @* This is the first widget carrying real controls, so it is the first to meet the drag handler
    HudHelper attaches to the widget host while the HUD is *unlocked*: a mousedown anywhere on the
-   host also starts a widget drag. That is the positioning mode, and locking the HUD (the default
-   state, Ctrl+Shift+Alt+L) detaches the handler and leaves the controls to themselves. Blazor's
-   @@onmousedown:stopPropagation cannot help here - it runs from Blazor's document-level delegate,
-   long after the event has bubbled past the host's own native listener. *@
-<WidgetHost Owner="this">
-    <div class="record-replay @(Active ? "" : "inactive")">
+   host also starts a widget drag, and Blazor's @@onmousedown:stopPropagation cannot help - it runs
+   from Blazor's document-level delegate, long after the event has bubbled past the host's own
+   native listener. Docking is the way out: a docked widget registers no drag handler at all, so
+   the scrubber works whether the HUD is locked or not. DockSide = Free restores the old behaviour
+   (and with it the old limitation, controls only while locked). *@
+<WidgetHost Owner="this" CssClass="@HostCssClass">
+    <div class="record-replay @HostCssClass @(Active ? "" : "inactive")">
+        @if (Active && Docked)
+        {
+            @* Collapsed state has to be readable on its own or the rail is just a mystery tab. *@
+            <div class="rail">
+                @if (IsRecording)
+                {
+                    <span class="rail-dot" style="background-color: @Settings!.RecordingColor"></span>
+                    <span class="rail-text" style="color: @Settings!.RecordingColor">@FormatDuration(RecordedElapsed)</span>
+                }
+                else if (ReplayController.IsLoaded)
+                {
+                    <span class="rail-glyph" style="color: @Settings!.ReplayColor">@(ReplayController.IsPlaying ? "▶" : "‖")</span>
+                    <span class="rail-text" style="color: @Settings!.ReplayColor">@FormatDuration(DisplayPosition)</span>
+                }
+                else
+                {
+                    <span class="rail-dot idle" style="background-color: @Settings!.LabelColor"></span>
+                    <span class="rail-text" style="color: @Settings!.LabelColor">Rec / Replay</span>
+                }
+            </div>
+        }
+
+        <div class="panel">
         @if (Active)
         {
             @if (RecordingOptions.Enabled)
@@ -121,6 +145,7 @@
                 </div>
             }
         }
+        </div>
     </div>
 </WidgetHost>
 
@@ -145,6 +170,22 @@
     public override double DefaultXPercent => 50;
     public override double DefaultYPercent => 90;
     public override bool Collidable => true;
+
+    /// <summary>
+    /// Dock classes for both the widget host (which they pin to a screen edge) and the widget's own
+    /// root (which they turn into a rail plus a sliding panel). Empty while free, so the widget
+    /// renders exactly as it did before docking existed.
+    /// </summary>
+    private string HostCssClass => Settings?.DockSide switch
+    {
+        WidgetDockSide.Left => "docked dock-left",
+        WidgetDockSide.Right => "docked dock-right",
+        _ => string.Empty
+    };
+
+    /// <summary>Scale about the docked edge, so a larger scale never grows off-screen.</summary>
+    protected override string DockedTransformOrigin
+        => Settings?.DockSide == WidgetDockSide.Right ? "top right" : "top left";
 
     public RecordReplay()
     {

--- a/R3E.YaHud/Components/Widget/RecordReplay/RecordReplay.razor
+++ b/R3E.YaHud/Components/Widget/RecordReplay/RecordReplay.razor
@@ -1,0 +1,393 @@
+@using System.Globalization
+@using Microsoft.Extensions.DependencyInjection
+@using R3E.Core.Recording
+@using R3E.Core.Replay
+@using R3E.Data
+@using R3E.YaHud.Components.Widget.Core
+@inherits HudWidgetBase<RecordReplaySettings>
+@inject RecordingOptions RecordingOptions
+@inject ReplayController ReplayController
+@inject IServiceProvider Services
+
+@* This is the first widget carrying real controls, so it is the first to meet the drag handler
+   HudHelper attaches to the widget host while the HUD is *unlocked*: a mousedown anywhere on the
+   host also starts a widget drag. That is the positioning mode, and locking the HUD (the default
+   state, Ctrl+Shift+Alt+L) detaches the handler and leaves the controls to themselves. Blazor's
+   @@onmousedown:stopPropagation cannot help here - it runs from Blazor's document-level delegate,
+   long after the event has bubbled past the host's own native listener. *@
+<WidgetHost Owner="this">
+    <div class="record-replay @(Active ? "" : "inactive")">
+        @if (Active)
+        {
+            @if (RecordingOptions.Enabled)
+            {
+                <div class="section">
+                    <div class="section-head">
+                        <span class="section-title" style="color: @Settings!.LabelColor">Record</span>
+                        <button class="transport @(IsRecording ? "on" : "")"
+                                style="color: @(IsRecording ? Settings!.RecordingColor : Settings!.LabelColor)"
+                                disabled="@ReplayController.IsLoaded"
+                                @onclick="ToggleRecording">
+                            @(IsRecording ? "Stop" : "Record")
+                        </button>
+                    </div>
+
+                    @if (ReplayController.IsLoaded)
+                    {
+                        <div class="note" style="color: @Settings!.LabelColor">Paused while replaying</div>
+                    }
+                    else
+                    {
+                        <div class="readout">
+                            <span class="value" style="color: @(IsRecording ? Settings!.RecordingColor : Settings!.LabelColor)">@FormatDuration(RecordedElapsed)</span>
+                            <span class="value" style="color: @Settings!.LabelColor">@FormatBytes(RecordedBytes)</span>
+                            @if (Settings!.ShowDroppedFrames)
+                            {
+                                <span class="value" style="color: @(RecordedDropped > 0 ? Settings!.RecordingColor : Settings!.LabelColor)">@RecordedDropped dropped</span>
+                            }
+                        </div>
+
+                        @if (Settings!.ShowFileName)
+                        {
+                            <div class="file" style="color: @Settings!.LabelColor">@(CurrentRecordingName ?? "no file yet")</div>
+                        }
+                    }
+                </div>
+            }
+
+            @if (ReplayController.IsLoaded)
+            {
+                <div class="section">
+                    <div class="section-head">
+                        <span class="section-title" style="color: @Settings!.LabelColor">Replay</span>
+                        <button class="transport" style="color: @Settings!.ReplayColor" @onclick="TogglePlay">
+                            @(ReplayController.IsPlaying ? "Pause" : "Play")
+                        </button>
+                        <button class="transport" style="color: @Settings!.LabelColor" @onclick="StepFrame">Step</button>
+                        <button class="transport" style="color: @Settings!.LabelColor" @onclick="StopReplay">Live</button>
+                    </div>
+
+                    <div class="timeline">
+                        <span class="time" style="color: @Settings!.LabelColor">@FormatDuration(DisplayPosition)</span>
+                        <div class="scrub">
+                            <input class="scrubber"
+                                   type="range"
+                                   min="0"
+                                   max="@ToInvariant(DurationSeconds)"
+                                   step="0.05"
+                                   value="@ToInvariant(SliderSeconds)"
+                                   @oninput="OnScrubInput"
+                                   @onchange="OnScrubCommit" />
+                            @if (ReplayController.IsCatchingUp)
+                            {
+                                <div class="catchup" style="background-color: @Settings!.CatchUpColor; width: @ToInvariant(ReplayController.CatchUpProgress * 100)%"></div>
+                            }
+                        </div>
+                        <span class="time" style="color: @Settings!.LabelColor">@FormatDuration(ReplayController.Duration)</span>
+                    </div>
+
+                    @if (ReplayController.IsCatchingUp)
+                    {
+                        <div class="note" style="color: @Settings!.CatchUpColor">
+                            Catching up @((ReplayController.CatchUpProgress * 100).ToString("F0", CultureInfo.InvariantCulture))%
+                        </div>
+                    }
+
+                    <div class="controls">
+                        <select class="picker" value="@ToInvariant(ReplayController.Speed)" @onchange="OnSpeedChanged">
+                            @foreach (var speed in SpeedPresets)
+                            {
+                                <option value="@ToInvariant(speed)">@(ToInvariant(speed))x</option>
+                            }
+                        </select>
+
+                        <select class="picker" value="" @onchange="OnJumpToLap">
+                            <option value="">Lap…</option>
+                            @foreach (var marker in ReplayController.LapMarkers)
+                            {
+                                <option value="@marker.Value">Lap @(marker.Value + 1)</option>
+                            }
+                        </select>
+                    </div>
+
+                    @if (Settings!.ShowReplayReadout)
+                    {
+                        <div class="readout">
+                            <span class="value" style="color: @Settings!.LabelColor">frame @ReplayController.FrameIndex</span>
+                            <span class="value" style="color: @Settings!.LabelColor">lap @CurrentLap</span>
+                            <span class="value" style="color: @Settings!.LabelColor">@CurrentPhase</span>
+                        </div>
+                    }
+                </div>
+            }
+        }
+    </div>
+</WidgetHost>
+
+@code {
+    /// <summary>Playback rates offered by the speed picker.</summary>
+    private static readonly double[] SpeedPresets = [0.1, 0.25, 0.5, 1, 2, 4, 8];
+
+    /// <summary>
+    /// How long the scrubber may sit still mid-drag before the position is committed. Dragging
+    /// itself never seeks: acting on every drag tick would fire a reset per pixel travelled on a
+    /// backward drag, each restarting playback from file start.
+    /// </summary>
+    private static readonly TimeSpan ScrubCommitDelay = TimeSpan.FromMilliseconds(150);
+
+    private TelemetryRecorder? recorder;
+    private System.Timers.Timer? scrubTimer;
+    private double? scrubPreviewSeconds;
+
+    public override string ElementId => "RecordReplayWidget";
+    public override string Name => "Record & Replay";
+    public override string Category => "Tools";
+    public override double DefaultXPercent => 50;
+    public override double DefaultYPercent => 90;
+    public override bool Collidable => true;
+
+    public RecordReplay()
+    {
+        // Displays no telemetry, so it must not subscribe to DataUpdated at 60 Hz. It re-renders
+        // off the recorder's and controller's own StateChanged events instead.
+        UseR3EData = false;
+    }
+
+    /// <summary>
+    /// Whether the widget draws anything on the HUD. It is always registered so it can be found
+    /// and positioned in the settings panel, but a user who never records never sees it.
+    /// </summary>
+    private bool Active => RecordingOptions.Enabled || ReplayController.IsLoaded;
+
+    private bool IsRecording => recorder?.IsRecording ?? false;
+    private TimeSpan RecordedElapsed => recorder?.Elapsed ?? TimeSpan.Zero;
+    private long RecordedBytes => recorder?.BytesWritten ?? 0;
+    private long RecordedDropped => recorder?.DroppedFrames ?? 0;
+
+    private string? CurrentRecordingName
+    {
+        get
+        {
+            var file = recorder?.CurrentFile;
+            return string.IsNullOrEmpty(file) ? null : System.IO.Path.GetFileName(file);
+        }
+    }
+
+    private double DurationSeconds => Math.Max(0.05, ReplayController.Duration.TotalSeconds);
+
+    /// <summary>Position shown in the readout: the drag preview while scrubbing, else the real one.</summary>
+    private TimeSpan DisplayPosition => scrubPreviewSeconds is { } preview
+        ? TimeSpan.FromSeconds(preview)
+        : ReplayController.Position;
+
+    private double SliderSeconds => scrubPreviewSeconds ?? ReplayController.Position.TotalSeconds;
+
+    private int CurrentLap => TelemetryService.Data.Raw.CompletedLaps + 1;
+
+    private string CurrentPhase
+    {
+        get
+        {
+            var phase = TelemetryService.Data.Raw.SessionPhase;
+            return Enum.IsDefined(typeof(Constant.SessionPhase), phase)
+                ? ((Constant.SessionPhase)phase).ToString()
+                : "unknown";
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        // The recorder is only registered when recording is enabled, so it must be resolved
+        // optionally - a required injection would throw for every user who has not passed --record.
+        recorder = Services.GetService<TelemetryRecorder>();
+
+        if (recorder is not null)
+        {
+            recorder.StateChanged += OnSourceStateChanged;
+        }
+
+        ReplayController.StateChanged += OnSourceStateChanged;
+    }
+
+    /// <summary>
+    /// Re-renders on the Blazor dispatcher. Both events are raised from background threads - the
+    /// recorder's writer task and the replay pump - so nothing here may touch the render tree
+    /// directly, and nothing here may block: calling back into the pump synchronously would make it
+    /// join itself.
+    /// </summary>
+    private void OnSourceStateChanged()
+    {
+        if (disposed)
+        {
+            return;
+        }
+
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private void ToggleRecording()
+    {
+        if (recorder is null)
+        {
+            return;
+        }
+
+        if (recorder.IsRecording)
+        {
+            recorder.Stop();
+        }
+        else
+        {
+            recorder.Start();
+        }
+    }
+
+    private void TogglePlay()
+    {
+        if (ReplayController.IsPlaying)
+        {
+            ReplayController.Pause();
+        }
+        else
+        {
+            ReplayController.Play();
+        }
+    }
+
+    private void StepFrame() => ReplayController.Step();
+
+    private void StopReplay() => ReplayController.Unload();
+
+    /// <summary>
+    /// Records the drag position without seeking. The scrubber is therefore never hard-locked, even
+    /// mid-catch-up.
+    /// </summary>
+    private void OnScrubInput(ChangeEventArgs e)
+    {
+        if (!TryReadSeconds(e, out var seconds))
+        {
+            return;
+        }
+
+        scrubPreviewSeconds = seconds;
+        RestartScrubTimer();
+    }
+
+    /// <summary>Commits the drag on release. The pump supersedes any in-flight seek by itself.</summary>
+    private void OnScrubCommit(ChangeEventArgs e)
+    {
+        if (TryReadSeconds(e, out var seconds))
+        {
+            scrubPreviewSeconds = seconds;
+        }
+
+        CommitScrub();
+    }
+
+    private void OnSpeedChanged(ChangeEventArgs e)
+    {
+        if (double.TryParse(e.Value?.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out var speed))
+        {
+            ReplayController.Speed = speed;
+        }
+    }
+
+    private void OnJumpToLap(ChangeEventArgs e)
+    {
+        if (int.TryParse(e.Value?.ToString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out var lap))
+        {
+            ReplayController.JumpToLap(lap);
+        }
+    }
+
+    private static bool TryReadSeconds(ChangeEventArgs e, out double seconds)
+        => double.TryParse(e.Value?.ToString(), NumberStyles.Float, CultureInfo.InvariantCulture, out seconds);
+
+    /// <summary>
+    /// Restarts the stillness timer, so a drag that stops without a release event still commits.
+    /// </summary>
+    private void RestartScrubTimer()
+    {
+        scrubTimer ??= CreateScrubTimer();
+        scrubTimer.Stop();
+        scrubTimer.Start();
+    }
+
+    private System.Timers.Timer CreateScrubTimer()
+    {
+        var timer = new System.Timers.Timer(ScrubCommitDelay.TotalMilliseconds) { AutoReset = false };
+        timer.Elapsed += (_, _) =>
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            // Routed through the dispatcher rather than seeking straight from the timer thread, so
+            // every seek this widget issues is raised from the same place.
+            _ = InvokeAsync(() =>
+            {
+                CommitScrub();
+                StateHasChanged();
+            });
+        };
+
+        return timer;
+    }
+
+    private void CommitScrub()
+    {
+        scrubTimer?.Stop();
+
+        if (scrubPreviewSeconds is not { } seconds)
+        {
+            return;
+        }
+
+        scrubPreviewSeconds = null;
+        ReplayController.Seek(TimeSpan.FromSeconds(seconds));
+    }
+
+    /// <summary>Nothing to show: this widget renders no telemetry.</summary>
+    protected override void UpdateWithTestData() { }
+
+    private static string ToInvariant(double value) => value.ToString("0.##", CultureInfo.InvariantCulture);
+
+    private static string FormatDuration(TimeSpan value)
+        => value.TotalHours >= 1 ? value.ToString(@"h\:mm\:ss") : value.ToString(@"mm\:ss");
+
+    private static string FormatBytes(long bytes)
+    {
+        if (bytes < 1024)
+        {
+            return $"{bytes} B";
+        }
+
+        if (bytes < 1024 * 1024)
+        {
+            return $"{bytes / 1024d:F1} KB";
+        }
+
+        return bytes < 1024L * 1024 * 1024
+            ? $"{bytes / (1024d * 1024d):F1} MB"
+            : $"{bytes / (1024d * 1024d * 1024d):F2} GB";
+    }
+
+    public override void Dispose()
+    {
+        if (recorder is not null)
+        {
+            recorder.StateChanged -= OnSourceStateChanged;
+        }
+
+        ReplayController.StateChanged -= OnSourceStateChanged;
+
+        scrubTimer?.Stop();
+        scrubTimer?.Dispose();
+        scrubTimer = null;
+
+        base.Dispose();
+    }
+}

--- a/R3E.YaHud/Components/Widget/RecordReplay/RecordReplay.razor.css
+++ b/R3E.YaHud/Components/Widget/RecordReplay/RecordReplay.razor.css
@@ -1,0 +1,132 @@
+.record-replay {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5vmin;
+    min-width: 26vmin;
+    max-width: fit-content;
+    box-sizing: border-box;
+}
+
+/* Recording disabled and nothing loaded: the widget stays in the DOM so drag registration and
+   positioning keep working, but it draws nothing on the HUD. */
+.record-replay.inactive {
+    display: none;
+}
+
+.section {
+    background-color: rgba(0, 0, 0, 0.75);
+    border: 0.1vmin solid #111;
+    border-radius: 0.5vmin;
+    box-shadow: 0 0 0.5vmin rgba(0, 0, 0, 0.5);
+    padding: 0.6vmin 0.8vmin;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4vmin;
+}
+
+.section-head {
+    display: flex;
+    align-items: center;
+    gap: 0.5vmin;
+}
+
+.section-title {
+    font-size: clamp(0.45rem, 0.5vw, 0.75rem);
+    font-weight: 700;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    margin-right: auto;
+}
+
+.transport {
+    background-color: rgba(255, 255, 255, 0.08);
+    border: 0.1vmin solid rgba(255, 255, 255, 0.15);
+    border-radius: 0.3vmin;
+    padding: 0.2vmin 0.6vmin;
+    font-size: clamp(0.45rem, 0.55vw, 0.8rem);
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+}
+
+.transport.on {
+    background-color: rgba(255, 255, 255, 0.18);
+}
+
+.transport:disabled {
+    opacity: 0.4;
+    cursor: default;
+}
+
+.readout {
+    display: flex;
+    gap: 0.8vmin;
+    flex-wrap: wrap;
+}
+
+.value {
+    font-size: clamp(0.5rem, 0.7vw, 1rem);
+    font-weight: 700;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+}
+
+.file,
+.note {
+    font-size: clamp(0.4rem, 0.45vw, 0.7rem);
+    line-height: 1.1;
+    overflow-wrap: anywhere;
+}
+
+.timeline {
+    display: flex;
+    align-items: center;
+    gap: 0.5vmin;
+}
+
+.time {
+    font-size: clamp(0.4rem, 0.5vw, 0.75rem);
+    font-variant-numeric: tabular-nums;
+}
+
+.scrub {
+    position: relative;
+    flex: 1 1 auto;
+    min-width: 12vmin;
+    display: flex;
+    align-items: center;
+}
+
+.scrubber {
+    width: 100%;
+    margin: 0;
+    cursor: pointer;
+}
+
+/* Catch-up progress sits under the slider so a multi-second rewind reads as progress, not a
+   freeze. It is decoration only - the slider itself stays live throughout. */
+.catchup {
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    height: 0.3vmin;
+    border-radius: 0.15vmin;
+    pointer-events: none;
+    opacity: 0.8;
+}
+
+.controls {
+    display: flex;
+    gap: 0.5vmin;
+}
+
+.picker {
+    background-color: rgba(255, 255, 255, 0.08);
+    color: #f1f1f1;
+    border: 0.1vmin solid rgba(255, 255, 255, 0.15);
+    border-radius: 0.3vmin;
+    font-size: clamp(0.4rem, 0.5vw, 0.75rem);
+    padding: 0.1vmin 0.3vmin;
+    cursor: pointer;
+}

--- a/R3E.YaHud/Components/Widget/RecordReplay/RecordReplay.razor.css
+++ b/R3E.YaHud/Components/Widget/RecordReplay/RecordReplay.razor.css
@@ -1,10 +1,144 @@
 .record-replay {
     display: flex;
     flex-direction: column;
-    gap: 0.5vmin;
     min-width: 26vmin;
     max-width: fit-content;
     box-sizing: border-box;
+}
+
+.panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5vmin;
+    box-sizing: border-box;
+}
+
+/* ---------------------------------------------------------------------------------------------
+   Docked layout: a slim rail on the screen edge, with the full panel parked out of sight behind
+   it and slid in on hover.
+
+   The panel stays in normal flow (it is what gives the container its height, so the rail can be
+   centred against it) and is moved with transform: translateX. Animating transform rather than
+   width keeps the transition off the layout path - animating width would reflow the whole panel,
+   sliders and selects included, on every frame.
+
+   The container is wider than the rail even while collapsed, so it is pointer-events: none and
+   only the rail and panel take the pointer. Otherwise an invisible strip down the edge of the
+   screen would swallow clicks and expand the panel from nowhere. overflow: hidden keeps the
+   parked panel from spilling past the viewport edge.
+   --------------------------------------------------------------------------------------------- */
+.record-replay.docked {
+    --rail-width: 2.4vmin;
+    --panel-width: 30vmin;
+    display: block;
+    position: relative;
+    width: calc(var(--panel-width) + var(--rail-width));
+    min-width: 0;
+    max-width: none;
+    overflow: hidden;
+    pointer-events: none;
+    /* Centres the widget on the host's 50% line. It lives here rather than on the host because the
+       host's transform is owned by HudHelper.setScale. */
+    transform: translateY(-50%);
+}
+
+.record-replay.docked > .panel {
+    width: var(--panel-width);
+    pointer-events: auto;
+    background-color: rgba(0, 0, 0, 0.85);
+    border-radius: 0.5vmin;
+    padding: 0.4vmin;
+    transition: transform 180ms ease;
+}
+
+.record-replay.docked > .rail {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: var(--rail-width);
+    z-index: 2;
+    pointer-events: auto;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.6vmin;
+    padding: 0.7vmin 0.2vmin;
+    background-color: rgba(0, 0, 0, 0.8);
+    border: 0.1vmin solid #111;
+    box-shadow: 0 0 0.5vmin rgba(0, 0, 0, 0.5);
+    cursor: pointer;
+}
+
+.rail-text {
+    writing-mode: vertical-rl;
+    text-orientation: mixed;
+    font-size: clamp(0.4rem, 0.45vw, 0.7rem);
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.rail-glyph {
+    font-size: clamp(0.45rem, 0.5vw, 0.75rem);
+    line-height: 1;
+}
+
+.rail-dot {
+    width: 0.8vmin;
+    height: 0.8vmin;
+    border-radius: 50%;
+    flex: none;
+}
+
+/* Only the live recording dot pulses; the idle one is a static hint that this is the rail. */
+.rail-dot:not(.idle) {
+    animation: rail-dot-pulse 1.2s ease-in-out infinite;
+}
+
+@keyframes rail-dot-pulse {
+    0%, 100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.25;
+    }
+}
+
+/* Right dock: rail hugs the right edge, panel parks off to the right behind it. */
+.record-replay.dock-right > .rail {
+    right: 0;
+    border-radius: 0.5vmin 0 0 0.5vmin;
+}
+
+.record-replay.dock-right > .panel {
+    margin-right: var(--rail-width);
+    transform: translateX(calc(100% + var(--rail-width)));
+}
+
+/* Left dock is the mirror image. */
+.record-replay.dock-left > .rail {
+    left: 0;
+    border-radius: 0 0.5vmin 0.5vmin 0;
+}
+
+.record-replay.dock-left > .panel {
+    margin-left: var(--rail-width);
+    transform: translateX(calc(-100% - var(--rail-width)));
+}
+
+/* :focus-within is not decoration here, it is what makes the scrubber usable. Dragging a slider
+   takes the pointer outside the panel constantly, and a :hover-only rule would collapse the panel
+   mid-drag and strand the drag. Clicking the slider focuses it, so focus-within holds the panel
+   open for the whole gesture and until the user clicks away - which is also the only keyboard
+   affordance available, since widget markup carries no aria/role attributes. */
+.record-replay.docked > .rail:hover ~ .panel,
+.record-replay.docked > .panel:hover,
+.record-replay.docked > .panel:focus-within {
+    transform: translateX(0);
 }
 
 /* Recording disabled and nothing loaded: the widget stays in the DOM so drag registration and

--- a/R3E.YaHud/Components/Widget/RecordReplay/RecordReplaySettings.cs
+++ b/R3E.YaHud/Components/Widget/RecordReplay/RecordReplaySettings.cs
@@ -1,0 +1,44 @@
+using R3E.YaHud.Components.Widget.Core;
+using R3E.YaHud.Services.Settings;
+
+namespace R3E.YaHud.Components.Widget.RecordReplay
+{
+    /// <summary>
+    /// Settings for the record and replay control widget.
+    /// </summary>
+    public class RecordReplaySettings : BasicSettings
+    {
+        private const string Red = "#FF3B30";
+        private const string Green = "#008000";
+        private const string Amber = "#FFB020";
+        private const string Grey = "#B5B5B5";
+
+        [SettingType("Show Recording File", SettingsTypes.Checkbox, 1,
+            Description = "Show the file the recorder is currently writing")]
+        public bool ShowFileName { get; set; } = true;
+
+        [SettingType("Show Dropped Frames", SettingsTypes.Checkbox, 2,
+            Description = "Show how many frames the recorder had to drop")]
+        public bool ShowDroppedFrames { get; set; } = true;
+
+        [SettingType("Show Replay Readout", SettingsTypes.Checkbox, 3,
+            Description = "Show the frame index, lap and session phase during replay")]
+        public bool ShowReplayReadout { get; set; } = true;
+
+        [SettingType("Recording Color", SettingsTypes.ColorPicker, 10,
+            ViewMode = SettingsViewMode.Intermediate)]
+        public string RecordingColor { get; set; } = Red;
+
+        [SettingType("Replay Color", SettingsTypes.ColorPicker, 11,
+            ViewMode = SettingsViewMode.Intermediate)]
+        public string ReplayColor { get; set; } = Green;
+
+        [SettingType("Catch Up Color", SettingsTypes.ColorPicker, 12,
+            ViewMode = SettingsViewMode.Intermediate)]
+        public string CatchUpColor { get; set; } = Amber;
+
+        [SettingType("Label Color", SettingsTypes.ColorPicker, 13,
+            ViewMode = SettingsViewMode.Intermediate)]
+        public string LabelColor { get; set; } = Grey;
+    }
+}

--- a/R3E.YaHud/Components/Widget/RecordReplay/RecordReplaySettings.cs
+++ b/R3E.YaHud/Components/Widget/RecordReplay/RecordReplaySettings.cs
@@ -13,6 +13,30 @@ namespace R3E.YaHud.Components.Widget.RecordReplay
         private const string Amber = "#FFB020";
         private const string Grey = "#B5B5B5";
 
+        private WidgetDockSide dockSide = WidgetDockSide.Right;
+
+        /// <summary>
+        /// Where the widget lives. Docked to an edge it collapses to a slim rail that expands on
+        /// hover, and - because a docked widget takes no drag handler - its transport controls work
+        /// whether the HUD is locked or not. <see cref="WidgetDockSide.Free"/> keeps the original
+        /// draggable behaviour for anyone who would rather place it themselves.
+        /// </summary>
+        [SettingType("Dock Side", SettingsTypes.Enum, 0,
+            Description = "Dock to a screen edge as a hover-expanding rail, or leave free to position by hand")]
+        public WidgetDockSide DockSide
+        {
+            get => dockSide;
+            set
+            {
+                if (value == dockSide) return;
+                dockSide = value;
+                NotifyPropertyChanged();
+            }
+        }
+
+        /// <inheritdoc />
+        public override bool Docked => DockSide != WidgetDockSide.Free;
+
         [SettingType("Show Recording File", SettingsTypes.Checkbox, 1,
             Description = "Show the file the recorder is currently writing")]
         public bool ShowFileName { get; set; } = true;

--- a/R3E.YaHud/Program.cs
+++ b/R3E.YaHud/Program.cs
@@ -1,6 +1,8 @@
 using Microsoft.AspNetCore.Components.Server;
 using Microsoft.AspNetCore.Connections;
 using R3E.Core.Interfaces;
+using R3E.Core.Recording;
+using R3E.Core.Replay;
 using R3E.Core.Services;
 using R3E.Core.SharedMemory;
 using R3E.Features.Driver;
@@ -26,6 +28,35 @@ var forceUdpOption = new Option<bool>("--force-udp")
     Description = "Receive telemetry over UDP from the relay instead of reading shared memory directly (Windows only; it is already the default elsewhere).",
 };
 
+// Recording is opt-in so nobody writes multi-GB files by accident. --record makes the feature
+// available but inert until started from the UI; --record-autostart is for scripted or headless
+// capture where there is nobody to press the button, and therefore implies --record.
+var recordOption = new Option<bool>("--record")
+{
+    Description = "Make telemetry recording available. Registers the recorder and shows the record controls; recording stays inert until started.",
+};
+var recordAutoStartOption = new Option<bool>("--record-autostart")
+{
+    Description = "Begin recording at launch without pressing the button. Implies --record.",
+};
+var recordingDirOption = new Option<string>("--recording-dir")
+{
+    Description = "Folder recordings are written to. Defaults to <LocalApplicationData>/YaHud/recordings.",
+    HelpName = "dir",
+};
+var recordingBlockSecondsOption = LaunchOptions.CreateIntOption(
+    "--recording-block-seconds",
+    "Compression block duration in seconds. Smaller blocks seek more finely but compress worse.",
+    RecordingOptions.DefaultBlockSeconds,
+    RecordingOptions.MinBlockSeconds,
+    RecordingOptions.MaxBlockSeconds,
+    "seconds");
+var replayOption = new Option<string>("--replay")
+{
+    Description = "Start in replay mode on this recording file instead of reading live telemetry.",
+    HelpName = "file",
+};
+
 var rootCommand = new RootCommand("YaHud - a web HUD for RaceRoom Racing Experience.")
 {
     // Host arguments such as --urls, --environment and --contentRoot must keep working, so
@@ -35,6 +66,11 @@ var rootCommand = new RootCommand("YaHud - a web HUD for RaceRoom Racing Experie
 rootCommand.Options.Add(webPortOption);
 rootCommand.Options.Add(udpPortOption);
 rootCommand.Options.Add(forceUdpOption);
+rootCommand.Options.Add(recordOption);
+rootCommand.Options.Add(recordAutoStartOption);
+rootCommand.Options.Add(recordingDirOption);
+rootCommand.Options.Add(recordingBlockSecondsOption);
+rootCommand.Options.Add(replayOption);
 
 var parsed = rootCommand.Parse(args);
 if (parsed.Errors.Count > 0 || parsed.Action is not null)
@@ -65,6 +101,26 @@ if (parsed.GetResult(forceUdpOption) is { Implicit: false })
 {
     overrides["YaHud:Udp:ForceUdp"] = parsed.GetValue(forceUdpOption).ToString();
 }
+if (parsed.GetResult(recordOption) is { Implicit: false })
+{
+    overrides["YaHud:Recording:Enabled"] = parsed.GetValue(recordOption).ToString();
+}
+if (parsed.GetResult(recordAutoStartOption) is { Implicit: false })
+{
+    overrides["YaHud:Recording:AutoStart"] = parsed.GetValue(recordAutoStartOption).ToString();
+}
+if (parsed.GetResult(recordingDirOption) is { Implicit: false })
+{
+    overrides["YaHud:Recording:Directory"] = parsed.GetValue(recordingDirOption);
+}
+if (parsed.GetResult(recordingBlockSecondsOption) is { Implicit: false })
+{
+    overrides["YaHud:Recording:BlockSeconds"] = parsed.GetValue(recordingBlockSecondsOption).ToString();
+}
+if (parsed.GetResult(replayOption) is { Implicit: false })
+{
+    overrides["YaHud:Replay:File"] = parsed.GetValue(replayOption);
+}
 builder.Configuration.AddInMemoryCollection(overrides);
 
 // Read through the same validation as the launch arguments: these values may also come from
@@ -76,13 +132,64 @@ if (!LaunchOptions.TryReadPort(builder.Configuration["YaHud:WebPort"], "--web-po
     return 1;
 }
 
-var rawForceUdp = builder.Configuration["YaHud:Udp:ForceUdp"];
-if (!string.IsNullOrWhiteSpace(rawForceUdp) && !bool.TryParse(rawForceUdp, out _))
+if (!LaunchOptions.TryReadBool(builder.Configuration["YaHud:Udp:ForceUdp"], "--force-udp (or YaHud:Udp:ForceUdp)", false, out var forceUdp, out configError)
+    || !LaunchOptions.TryReadBool(builder.Configuration["YaHud:Recording:Enabled"], "--record (or YaHud:Recording:Enabled)", false, out var recordEnabled, out configError)
+    || !LaunchOptions.TryReadBool(builder.Configuration["YaHud:Recording:AutoStart"], "--record-autostart (or YaHud:Recording:AutoStart)", false, out var recordAutoStart, out configError)
+    || !LaunchOptions.TryReadInt(builder.Configuration["YaHud:Recording:BlockSeconds"], "--recording-block-seconds (or YaHud:Recording:BlockSeconds)", RecordingOptions.DefaultBlockSeconds, RecordingOptions.MinBlockSeconds, RecordingOptions.MaxBlockSeconds, out var blockSeconds, out configError))
 {
-    Console.Error.WriteLine($"--force-udp (or YaHud:Udp:ForceUdp) must be true or false, but was '{rawForceUdp}'.");
+    Console.Error.WriteLine(configError);
     return 1;
 }
-var forceUdp = bool.TryParse(rawForceUdp, out var parsedForceUdp) && parsedForceUdp;
+
+// AutoStart is only meaningful if the feature is available at all, so it implies Enabled - a user
+// who asked to start recording immediately plainly wants recording.
+var recordingOptions = new RecordingOptions
+{
+    Enabled = recordEnabled || recordAutoStart,
+    AutoStart = recordAutoStart,
+    Directory = builder.Configuration["YaHud:Recording:Directory"],
+    BlockSeconds = blockSeconds,
+};
+
+// Fail here rather than at the first frame: by then the user is driving, the HUD looks fine, and
+// the only symptom is that no file ever appears.
+if (recordingOptions.Enabled)
+{
+    try
+    {
+        Directory.CreateDirectory(recordingOptions.ResolveDirectory());
+    }
+    catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+    {
+        Console.Error.WriteLine($"--recording-dir (or YaHud:Recording:Directory) could not be created: '{recordingOptions.ResolveDirectory()}'. {ex.Message}");
+        return 1;
+    }
+}
+
+// Likewise for replay: a mistyped path should say so now, not surface as an empty HUD.
+var replayFile = builder.Configuration["YaHud:Replay:File"];
+if (!string.IsNullOrWhiteSpace(replayFile))
+{
+    try
+    {
+        replayFile = Path.GetFullPath(replayFile);
+    }
+    catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+    {
+        Console.Error.WriteLine($"--replay (or YaHud:Replay:File) is not a usable path: '{replayFile}'. {ex.Message}");
+        return 1;
+    }
+
+    if (!File.Exists(replayFile))
+    {
+        Console.Error.WriteLine($"--replay (or YaHud:Replay:File) must point at an existing recording, but '{replayFile}' does not exist.");
+        return 1;
+    }
+}
+else
+{
+    replayFile = null;
+}
 
 // UseUrls overrides --urls and ASPNETCORE_URLS, so only bind explicitly when the user asked for a
 // port or nothing else has set the URLs.
@@ -122,28 +229,54 @@ builder.Services.AddScoped<VisibilityService>();
 builder.Services.AddScoped<TestModeService>();
 builder.Services.AddSingleton<ShortcutService>();
 
-// Register appropriate ISharedSource based on OS, unless --force-udp overrides it
+// Register the appropriate live telemetry source based on OS, unless --force-udp overrides it.
+// Note what is deliberately absent: neither is registered as ISharedSource any more. That
+// registration now belongs to SharedSourceSwitch, so replay can take over at runtime without a
+// restart. Each live source is still registered as itself (so the switch can be handed the
+// concrete instance) and as IHostedService (so the host starts and stops it as before).
+Func<IServiceProvider, ISharedSource> resolveLiveSource;
 if (OperatingSystem.IsWindows() && !forceUdp)
 {
     builder.Services.AddSingleton<SharedMemoryService>();
-    builder.Services.AddSingleton<ISharedSource>(sp =>
-    {
-#pragma warning disable CA1416 // Validate platform compatibility
-        return sp.GetRequiredService<SharedMemoryService>();
-#pragma warning restore CA1416 // Validate platform compatibility
-    });
     builder.Services.AddSingleton<IHostedService>(sp =>
     {
 #pragma warning disable CA1416 // Validate platform compatibility
         return sp.GetRequiredService<SharedMemoryService>();
 #pragma warning restore CA1416 // Validate platform compatibility
     });
+    resolveLiveSource = sp =>
+    {
+#pragma warning disable CA1416 // Validate platform compatibility
+        return sp.GetRequiredService<SharedMemoryService>();
+#pragma warning restore CA1416 // Validate platform compatibility
+    };
 }
 else
 {
     builder.Services.AddSingleton(sp => new RemoteSharedMemoryService(udpPort, sp.GetRequiredService<ILoggerFactory>()));
-    builder.Services.AddSingleton<ISharedSource>(sp => sp.GetRequiredService<RemoteSharedMemoryService>());
     builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<RemoteSharedMemoryService>());
+    resolveLiveSource = sp => sp.GetRequiredService<RemoteSharedMemoryService>();
+}
+
+// Replay is a third ISharedSource, in-process: no UDP hop and no second application. The switch
+// forwards whichever of the two is active, so ITelemetryService subscribes once at construction
+// and never notices a swap.
+builder.Services.AddSingleton<FileSharedSource>();
+builder.Services.AddSingleton(sp => new SharedSourceSwitch(
+    resolveLiveSource(sp),
+    sp.GetRequiredService<FileSharedSource>(),
+    sp.GetRequiredService<ILogger<SharedSourceSwitch>>()));
+builder.Services.AddSingleton<ISharedSource>(sp => sp.GetRequiredService<SharedSourceSwitch>());
+builder.Services.AddSingleton<ReplayController>();
+
+// Recording options are always registered so the UI can read them and explain why the controls are
+// hidden; the recorder itself is only registered when the feature is enabled, so a default launch
+// carries none of its cost. It stays inert until started unless AutoStart is set.
+builder.Services.AddSingleton(recordingOptions);
+if (recordingOptions.Enabled)
+{
+    builder.Services.AddSingleton<TelemetryRecorder>();
+    builder.Services.AddSingleton<IHostedService>(sp => sp.GetRequiredService<TelemetryRecorder>());
 }
 
 // Core services
@@ -170,6 +303,35 @@ if (bindHudUrl)
 if (forceUdp && OperatingSystem.IsWindows())
 {
     app.Logger.LogWarning("--force-udp is set: receiving telemetry over UDP on port {Port} instead of reading shared memory. The relay must be running.", udpPort);
+}
+if (recordingOptions.Enabled)
+{
+    app.Logger.LogInformation("Telemetry recording is enabled: writing {BlockSeconds}s blocks to {Directory}.", recordingOptions.BlockSeconds, recordingOptions.ResolveDirectory());
+    if (recordingOptions.AutoStart)
+    {
+        app.Logger.LogInformation("--record-autostart is set: recording begins as soon as the first telemetry frame arrives.");
+    }
+}
+
+// Resolve the switch eagerly. It subscribes to the live source in its constructor, and every other
+// consumer reaches it lazily through ISharedSource - the first Blazor circuit, or the recorder.
+// Creating it here makes that subscription happen at a known point instead of whenever the first
+// browser connects, and turns a misconfiguration into a startup failure rather than a blank HUD.
+_ = app.Services.GetRequiredService<SharedSourceSwitch>();
+
+if (replayFile is not null)
+{
+    // --replay pre-selects replay mode, so a recording can be opened without touching the UI.
+    try
+    {
+        app.Services.GetRequiredService<ReplayController>().Load(replayFile);
+        app.Logger.LogInformation("--replay is set: starting in replay mode on {File}. Live telemetry is not being read.", replayFile);
+    }
+    catch (Exception ex)
+    {
+        app.Logger.LogError(ex, "Could not open the recording '{File}'.", replayFile);
+        return 1;
+    }
 }
 
 // Last-resort safety net: a fault in a background task (e.g. a widget update or a telemetry

--- a/R3E.YaHud/appsettings.json
+++ b/R3E.YaHud/appsettings.json
@@ -14,6 +14,15 @@
     "Udp": {
       "Port": 10101,
       "ForceUdp": false
+    },
+    "Recording": {
+      "Enabled": false,
+      "AutoStart": false,
+      "Directory": null,
+      "BlockSeconds": 3
+    },
+    "Replay": {
+      "File": null
     }
   }
 }

--- a/R3E.YaHud/wwwroot/js/HudHelper.js
+++ b/R3E.YaHud/wwwroot/js/HudHelper.js
@@ -506,6 +506,68 @@ window.HudHelper = (function () {
             } catch (e) {
                 console.warn('HudHelper.clearWidgetSettings: localStorage error', e);
             }
+        },
+
+        // The replay scrubber's live-drag handling lives here, entirely client-side. A Blazor Server
+        // round trip per native 'input' event (fired on every pixel of a drag) queues over SignalR;
+        // under any circuit load those can back up and keep delivering stale positions for seconds
+        // after release. Worse, a slider whose `value` is bound reactively in Razor gets that
+        // attribute re-rendered on every server-side tick (e.g. a still-playing replay advancing the
+        // position ~10x/second) - fighting the user's own drag regardless of direction. So the input
+        // is left uncontrolled from Blazor's side: dragging, the live label, and the thumb position
+        // are all handled here, and only the final 'change' (one event, on release) reaches C#.
+        formatScrubberDuration: function (totalSeconds) {
+            if (!isFinite(totalSeconds) || totalSeconds < 0) {
+                totalSeconds = 0;
+            }
+
+            const total = Math.floor(totalSeconds);
+            const hours = Math.floor(total / 3600);
+            const minutes = Math.floor((total % 3600) / 60);
+            const seconds = total % 60;
+            const pad = (n) => n.toString().padStart(2, '0');
+
+            return hours >= 1 ? `${hours}:${pad(minutes)}:${pad(seconds)}` : `${pad(minutes)}:${pad(seconds)}`;
+        },
+
+        bindScrubber: function (inputId, labelId) {
+            const input = document.getElementById(inputId);
+            if (!input || input.dataset.scrubberBound === '1') {
+                return;
+            }
+
+            input.dataset.scrubberBound = '1';
+            input.dataset.dragging = '0';
+
+            const updateLabel = () => {
+                const label = document.getElementById(labelId);
+                if (label) {
+                    label.textContent = HudHelper.formatScrubberDuration(parseFloat(input.value));
+                }
+            };
+
+            input.addEventListener('pointerdown', () => { input.dataset.dragging = '1'; });
+            input.addEventListener('input', updateLabel);
+
+            // A drag that ends outside the input (mouse released elsewhere, or a touch cancelled)
+            // still has to clear the flag, or the slider would stop following playback forever.
+            const clearDragging = () => { input.dataset.dragging = '0'; };
+            input.addEventListener('change', clearDragging);
+            window.addEventListener('pointerup', clearDragging, { passive: true });
+        },
+
+        setScrubberValueIfIdle: function (inputId, seconds, labelId) {
+            const input = document.getElementById(inputId);
+            if (!input || input.dataset.dragging === '1') {
+                return;
+            }
+
+            input.value = seconds;
+
+            const label = document.getElementById(labelId);
+            if (label) {
+                label.textContent = HudHelper.formatScrubberDuration(seconds);
+            }
         }
     };
 })();

--- a/R3E.YaHud/wwwroot/js/HudHelper.js
+++ b/R3E.YaHud/wwwroot/js/HudHelper.js
@@ -155,6 +155,13 @@ window.HudHelper = (function () {
         const dotnetHelper = entry.dotNetRef;
 
         function onMouseDown(e) {
+            // A docked widget is placed by its own CSS, so left-drag must not move it. Bailing out
+            // before anything else is exactly what leaves its controls usable while the HUD is
+            // unlocked: no drag starts, no window listeners are added, and the slider or button
+            // under the pointer gets the gesture to itself. Right-button scaling still applies -
+            // it is the same listener, but it is not what fights the controls.
+            if (entry.draggable === false && e.button !== 2) return;
+
             // only left button
             if (!entry.isScaling && e.button == 0) {
                 el.style.transformOrigin = "top left";
@@ -330,7 +337,10 @@ window.HudHelper = (function () {
     }
 
     return {
-        registerTransformable: function (elementId, dotnetHelper, locked, collidable) {
+        // draggable defaults to true so every existing caller keeps its drag handler. Docked widgets
+        // pass false: they are placed by their own CSS and must not start a widget drag, which is
+        // what lets their controls work while the HUD is unlocked.
+        registerTransformable: function (elementId, dotnetHelper, locked, collidable, draggable = true) {
             const el = document.getElementById(elementId);
             if (!el) {
                 console.warn('HudHelper.registerTransformable: element not found', elementId);
@@ -339,11 +349,15 @@ window.HudHelper = (function () {
             // if already registered, update dotnetRef and locked state
             let entry = registry[elementId];
             if (!entry) {
-                entry = { el: el, dotNetRef: dotnetHelper, isDragging: false, isScaling: false, handlersAttached: false, raf: null, id: elementId, collidable: !!collidable };
+                entry = { el: el, dotNetRef: dotnetHelper, isDragging: false, isScaling: false, handlersAttached: false, raf: null, id: elementId, collidable: !!collidable, draggable: draggable !== false };
                 registry[elementId] = entry;
             } else {
+                entry.el = el;
                 entry.dotNetRef = dotnetHelper;
                 entry.collidable = !!collidable;
+                // Read live by the mousedown handler, so flipping the dock setting at runtime takes
+                // effect without re-attaching anything.
+                entry.draggable = draggable !== false;
             }
 
             // ensure consistent transform origin so scaling doesn't shift element unexpectedly
@@ -354,13 +368,13 @@ window.HudHelper = (function () {
         },
 
         enableTransformation: function (elementId) {
-            const el = document.getElementById(elementId);
             const entry = registry[elementId];
-            entry.el = el;
             if (!entry) {
                 console.warn('HudHelper.enableTransformation: element not registered', elementId);
                 return;
             }
+            const el = document.getElementById(elementId);
+            if (el) entry.el = el;
             attachHandlers(entry);
         },
 
@@ -396,6 +410,21 @@ window.HudHelper = (function () {
                 el.style.left = (xPercent / 100 * window.innerWidth) - (el.offsetWidth / 2) + "px";
                 el.style.top = (yPercent / 100 * window.innerHeight) - (el.offsetHeight / 2) + "px";
 
+        },
+
+        // Hands placement back to the stylesheet: drops the inline position setPosition (or a drag)
+        // left behind, and anchors scaling to the docked edge so a scale above 1 grows inwards
+        // instead of pushing the widget off-screen.
+        dockElement: function (elementId, transformOrigin) {
+            const el = document.getElementById(elementId);
+            if (!el) {
+                console.warn('HudHelper.dockElement: element not found', elementId);
+                return;
+            }
+            el.style.position = '';
+            el.style.left = '';
+            el.style.top = '';
+            el.style.transformOrigin = transformOrigin || 'top left';
         },
 
         setScale: function (elementId, scale) {

--- a/R3E/Core/Interfaces/ISharedSource.cs
+++ b/R3E/Core/Interfaces/ISharedSource.cs
@@ -12,6 +12,12 @@ namespace R3E.Core.Interfaces
         /// the shared data can be updated from multiple threads.</remarks>
         event Action<Shared>? DataUpdated;
 
+        /// <summary>Raw unmarshalled frame bytes. The buffer is reused; copy synchronously.</summary>
+        /// <remarks>Raised before <see cref="DataUpdated"/> so a throwing downstream handler cannot
+        /// lose the frame for subscribers that persist it. Handlers must not retain the memory past
+        /// the call — the underlying buffer is overwritten by the next frame.</remarks>
+        event Action<ReadOnlyMemory<byte>>? RawFrameReceived;
+
         /// <summary>
         /// Occurs when start lights changes.
         /// </summary>

--- a/R3E/Core/Interfaces/ISwitchableSharedSource.cs
+++ b/R3E/Core/Interfaces/ISwitchableSharedSource.cs
@@ -1,0 +1,22 @@
+namespace R3E.Core.Interfaces
+{
+    /// <summary>
+    /// A <see cref="ISharedSource"/> that can swap the underlying source at runtime, so the HUD can
+    /// move between live telemetry and a replayed recording without restarting.
+    /// </summary>
+    /// <remarks>
+    /// Consumers that accumulate state across frames need to know a swap happened: the two sources
+    /// are unrelated streams, so everything derived from the old one is stale. The swap deliberately
+    /// carries no frame with it - fabricating a zeroed <c>Shared</c> to force a discontinuity would
+    /// push a zero session type and zero track length through every feature service, which is the
+    /// exact "plausible but wrong" failure this reset exists to prevent.
+    /// </remarks>
+    public interface ISwitchableSharedSource : ISharedSource
+    {
+        /// <summary>Raised after the active source has been swapped, before any frame from it is forwarded.</summary>
+        event Action? ActiveSourceChanged;
+
+        /// <summary>Whether the active source is currently a recording rather than live telemetry.</summary>
+        bool IsReplaying { get; }
+    }
+}

--- a/R3E/Core/Interfaces/ITelemetryService.cs
+++ b/R3E/Core/Interfaces/ITelemetryService.cs
@@ -8,6 +8,15 @@ namespace R3E.Core.Interfaces
         event Action<int>? StartLightsChanged;
         event Action<TelemetryData>? NewLap;
         event Action<TelemetryData>? SessionTypeChanged;
+
+        /// <summary>
+        /// Raised when accumulated telemetry state must be discarded: the session type changed, or
+        /// simulation ticks went backwards (a session restart, RaceRoom's own replay, or a replay
+        /// rewind). Consumers that carry state across frames should reset on this rather than on
+        /// <see cref="SessionTypeChanged"/>.
+        /// </summary>
+        event Action<TelemetryData>? TelemetryReset;
+
         event Action<TelemetryData>? SessionPhaseChanged;
         event Action<TelemetryData>? CarPositionChanged;
         event Action<TelemetryData>? TrackChanged;

--- a/R3E/Core/Interfaces/ITelemetryService.cs
+++ b/R3E/Core/Interfaces/ITelemetryService.cs
@@ -13,7 +13,8 @@ namespace R3E.Core.Interfaces
         /// Raised when accumulated telemetry state must be discarded: the session type changed, or
         /// simulation ticks went backwards (a session restart, RaceRoom's own replay, or a replay
         /// rewind). Consumers that carry state across frames should reset on this rather than on
-        /// <see cref="SessionTypeChanged"/>.
+        /// <see cref="SessionTypeChanged"/>, which means only what its name says. It is raised
+        /// before the other per-frame events for that frame.
         /// </summary>
         event Action<TelemetryData>? TelemetryReset;
 

--- a/R3E/Core/Recording/FrameTruncation.cs
+++ b/R3E/Core/Recording/FrameTruncation.cs
@@ -1,0 +1,161 @@
+using R3E.Data;
+using System.Runtime.InteropServices;
+
+namespace R3E.Core.Recording
+{
+    /// <summary>
+    /// Truncates and restores raw <see cref="Shared"/> frames around the variable-size driver tail.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>NumCars</c> followed by <c>DriverData[128]</c> are the last fields of <see cref="Shared"/>,
+    /// so "store only the drivers that exist" is a pure byte-range truncation: keep everything up to
+    /// and including <c>NumCars</c>, then keep exactly <c>NumCars</c> driver slots. Restoring is a
+    /// zero-filled buffer plus a copy — absent driver slots are zeros, which is exactly what the game
+    /// would have had for them.
+    /// </para>
+    /// <para>
+    /// Offsets are resolved once via <see cref="Marshal.OffsetOf{T}(string)"/>, mirroring the pattern
+    /// already used by <c>SharedMemoryService</c>, so the code stays correct if the layout moves.
+    /// </para>
+    /// </remarks>
+    public static class FrameTruncation
+    {
+        /// <summary>Maximum number of driver slots in <see cref="Shared"/>.</summary>
+        public const int MaxDrivers = 128;
+
+        /// <summary>Full marshalled size of <see cref="Shared"/>, in bytes.</summary>
+        public static int SizeOfShared { get; }
+
+        /// <summary>Byte offset of <c>Shared.NumCars</c>, i.e. the start of the variable-size tail.</summary>
+        public static int NumCarsOffset { get; }
+
+        /// <summary>Marshalled size of a single <see cref="DriverData"/> entry, in bytes.</summary>
+        public static int DriverDataSize { get; }
+
+        /// <summary>Smallest valid truncated frame: everything up to and including <c>NumCars</c>.</summary>
+        public static int MinTruncatedLength => NumCarsOffset + sizeof(int);
+
+        static FrameTruncation()
+        {
+            SizeOfShared = Marshal.SizeOf<Shared>();
+            NumCarsOffset = (int)Marshal.OffsetOf<Shared>(nameof(Shared.NumCars));
+            DriverDataSize = Marshal.SizeOf<DriverData>();
+        }
+
+        /// <summary>
+        /// Reads <c>NumCars</c> out of a raw frame without marshalling, clamped to
+        /// <c>[0, <see cref="MaxDrivers"/>]</c> so a garbage frame cannot produce a wild length.
+        /// </summary>
+        /// <param name="frame">A full or truncated raw frame.</param>
+        /// <returns>The clamped driver count, or 0 if the frame is too short to contain the field.</returns>
+        public static int ReadNumCars(ReadOnlySpan<byte> frame)
+        {
+            if (frame.Length < MinTruncatedLength)
+            {
+                return 0;
+            }
+
+            var numCars = BitConverter.ToInt32(frame[NumCarsOffset..]);
+            return Math.Clamp(numCars, 0, MaxDrivers);
+        }
+
+        /// <summary>
+        /// Slices the populated prefix out of a full-size raw frame.
+        /// </summary>
+        /// <param name="full">A full-size raw frame, <see cref="SizeOfShared"/> bytes.</param>
+        /// <param name="length">Receives the truncated length in bytes.</param>
+        /// <returns>The truncated slice of <paramref name="full"/>. No copy is made.</returns>
+        /// <exception cref="ArgumentException"><paramref name="full"/> is not a full-size frame.</exception>
+        public static ReadOnlySpan<byte> Truncate(ReadOnlySpan<byte> full, out int length)
+        {
+            if (full.Length != SizeOfShared)
+            {
+                throw new ArgumentException(
+                    $"Expected a full frame of {SizeOfShared} bytes but got {full.Length}.", nameof(full));
+            }
+
+            var numCars = ReadNumCars(full);
+            length = MinTruncatedLength + (numCars * DriverDataSize);
+
+            // Cannot exceed the source; belt and braces against a layout mismatch.
+            if (length > full.Length)
+            {
+                length = full.Length;
+            }
+
+            return full[..length];
+        }
+
+        /// <summary>
+        /// Rebuilds a full-size raw frame from a truncated one. Driver slots beyond <c>NumCars</c>
+        /// are zeroed.
+        /// </summary>
+        /// <param name="truncated">A frame previously produced by <see cref="Truncate"/>.</param>
+        /// <param name="full">Destination buffer of exactly <see cref="SizeOfShared"/> bytes.</param>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="full"/> is not <see cref="SizeOfShared"/> bytes, or
+        /// <paramref name="truncated"/> is too short or longer than a full frame.
+        /// </exception>
+        public static void Restore(ReadOnlySpan<byte> truncated, Span<byte> full)
+        {
+            if (full.Length != SizeOfShared)
+            {
+                throw new ArgumentException(
+                    $"Destination must be {SizeOfShared} bytes but was {full.Length}.", nameof(full));
+            }
+
+            if (truncated.Length < MinTruncatedLength || truncated.Length > SizeOfShared)
+            {
+                throw new ArgumentException(
+                    $"Truncated frame length {truncated.Length} is outside [{MinTruncatedLength}, {SizeOfShared}].",
+                    nameof(truncated));
+            }
+
+            full.Clear();
+            truncated.CopyTo(full);
+        }
+
+        /// <summary>
+        /// Allocates and rebuilds a full-size raw frame. Convenience wrapper over
+        /// <see cref="Restore(ReadOnlySpan{byte}, Span{byte})"/> for callers without a pooled buffer.
+        /// </summary>
+        /// <param name="truncated">A frame previously produced by <see cref="Truncate"/>.</param>
+        /// <returns>A newly allocated full-size frame.</returns>
+        public static byte[] Restore(ReadOnlySpan<byte> truncated)
+        {
+            var full = new byte[SizeOfShared];
+            Restore(truncated, full);
+            return full;
+        }
+
+        /// <summary>
+        /// Cross-checks the frame's own self-describing layout fields (<c>AllDriversOffset</c> and
+        /// <c>DriverDataSize</c>) against the offsets resolved from the compiled struct.
+        /// </summary>
+        /// <param name="frame">A full or truncated raw frame.</param>
+        /// <returns><see langword="true"/> when the frame's layout matches this build.</returns>
+        public static bool MatchesLayout(ReadOnlySpan<byte> frame)
+        {
+            var allDriversOffset = (int)Marshal.OffsetOf<Shared>(nameof(Shared.AllDriversOffset));
+            var driverDataSizeOffset = (int)Marshal.OffsetOf<Shared>(nameof(Shared.DriverDataSize));
+
+            if (frame.Length < driverDataSizeOffset + sizeof(int))
+            {
+                return false;
+            }
+
+            var reportedOffset = BitConverter.ToInt32(frame[allDriversOffset..]);
+            var reportedSize = BitConverter.ToInt32(frame[driverDataSizeOffset..]);
+
+            // A frame that has never been written by the game reports zeros; treat that as unknown
+            // rather than as a mismatch.
+            if (reportedOffset == 0 && reportedSize == 0)
+            {
+                return true;
+            }
+
+            return reportedOffset == NumCarsOffset && reportedSize == DriverDataSize;
+        }
+    }
+}

--- a/R3E/Core/Recording/RecordingOptions.cs
+++ b/R3E/Core/Recording/RecordingOptions.cs
@@ -1,0 +1,49 @@
+namespace R3E.Core.Recording
+{
+    /// <summary>
+    /// Recording settings, mapping one-to-one onto the <c>YaHud:Recording</c> configuration section
+    /// and its launch-argument equivalents.
+    /// </summary>
+    /// <remarks>Populated by agent B5 from configuration and launch arguments.</remarks>
+    public sealed class RecordingOptions
+    {
+        /// <summary>Configuration section these options bind to.</summary>
+        public const string SectionName = "YaHud:Recording";
+
+        /// <summary>
+        /// Whether recording is available at all (<c>--record</c>). When false the recorder is not
+        /// registered and the UI toggle is hidden. Opt-in so nobody writes multi-GB files by accident.
+        /// </summary>
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Begin recording at launch without pressing the button (<c>--record-autostart</c>), for
+        /// scripted or headless capture. Implies <see cref="Enabled"/>.
+        /// </summary>
+        public bool AutoStart { get; set; }
+
+        /// <summary>
+        /// Output folder (<c>--recording-dir</c>). When null, defaults to
+        /// <c>LocalApplicationData/YaHud/recordings</c>, which resolves on both Windows and Linux.
+        /// </summary>
+        public string? Directory { get; set; }
+
+        /// <summary>Compression block duration in seconds (<c>--recording-block-seconds</c>).</summary>
+        public int BlockSeconds { get; set; } = 3;
+
+        /// <summary>
+        /// Resolves <see cref="Directory"/>, falling back to the platform default when unset.
+        /// </summary>
+        /// <returns>An absolute path to the recordings root folder.</returns>
+        public string ResolveDirectory()
+        {
+            if (!string.IsNullOrWhiteSpace(Directory))
+            {
+                return System.IO.Path.GetFullPath(Directory);
+            }
+
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            return System.IO.Path.Combine(localAppData, "YaHud", "recordings");
+        }
+    }
+}

--- a/R3E/Core/Recording/RecordingOptions.cs
+++ b/R3E/Core/Recording/RecordingOptions.cs
@@ -10,6 +10,21 @@ namespace R3E.Core.Recording
         /// <summary>Configuration section these options bind to.</summary>
         public const string SectionName = "YaHud:Recording";
 
+        /// <summary>Default compression block duration in seconds.</summary>
+        public const int DefaultBlockSeconds = 3;
+
+        /// <summary>
+        /// Smallest accepted <see cref="BlockSeconds"/>. Below this the footer index grows faster
+        /// than the seek granularity it buys, and every block restarts the Brotli dictionary.
+        /// </summary>
+        public const int MinBlockSeconds = 1;
+
+        /// <summary>
+        /// Largest accepted <see cref="BlockSeconds"/>. Above this a seek has to decode an
+        /// unreasonable amount of data to reach its target.
+        /// </summary>
+        public const int MaxBlockSeconds = 60;
+
         /// <summary>
         /// Whether recording is available at all (<c>--record</c>). When false the recorder is not
         /// registered and the UI toggle is hidden. Opt-in so nobody writes multi-GB files by accident.
@@ -29,7 +44,7 @@ namespace R3E.Core.Recording
         public string? Directory { get; set; }
 
         /// <summary>Compression block duration in seconds (<c>--recording-block-seconds</c>).</summary>
-        public int BlockSeconds { get; set; } = 3;
+        public int BlockSeconds { get; set; } = DefaultBlockSeconds;
 
         /// <summary>
         /// Resolves <see cref="Directory"/>, falling back to the platform default when unset.

--- a/R3E/Core/Recording/TelemetryRecorder.cs
+++ b/R3E/Core/Recording/TelemetryRecorder.cs
@@ -1,0 +1,105 @@
+using R3E.Core.Interfaces;
+
+namespace R3E.Core.Recording
+{
+    /// <summary>
+    /// Subscribes to <see cref="ISharedSource.RawFrameReceived"/> and persists raw telemetry to
+    /// <c>.yhtl</c> files, one file per session.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The ingest loop must never wait on disk. <c>RawFrameReceived</c> fires synchronously on the
+    /// polling thread, so a disk hiccup, AV scan or full buffer would otherwise stall telemetry and
+    /// visibly freeze the HUD. The write path is therefore: truncate into an <c>ArrayPool</c> buffer,
+    /// push onto a bounded channel with <c>DropWrite</c>, and let a background writer task compress
+    /// and write. For a debug recorder, dropping frames beats stuttering the HUD, and every frame is
+    /// independently decodable, so a gap only shows as a longer inter-frame delta on replay.
+    /// </para>
+    /// <para>
+    /// One recording run produces one file per session. The recorder watches <c>SessionType</c> and
+    /// <c>TrackId</c> straight out of the raw buffer — no marshalling — and on a change finalises the
+    /// current file and opens a new one on the next frame. Files live in a per-run folder so the
+    /// sessions of a stint stay together.
+    /// </para>
+    /// <para>Implemented by agent B2.</para>
+    /// </remarks>
+    public sealed class TelemetryRecorder : IHostedService, IAsyncDisposable
+    {
+        /// <summary>
+        /// Creates the recorder. It stays inert until <see cref="Start"/> is called, or immediately
+        /// starts when <see cref="RecordingOptions.AutoStart"/> is set.
+        /// </summary>
+        /// <param name="sharedSource">The source whose raw frames are captured.</param>
+        /// <param name="options">Recording settings from configuration and launch arguments.</param>
+        /// <param name="logger">Optional logger.</param>
+        /// <remarks>Implemented by agent B2.</remarks>
+        public TelemetryRecorder(ISharedSource sharedSource, RecordingOptions options, ILogger<TelemetryRecorder>? logger = null)
+            => throw new NotImplementedException("Implemented by agent B2");
+
+        /// <summary>Raised whenever any of the state below changes, so the UI can re-render.</summary>
+#pragma warning disable CS0067 // Event is never used - raised by agent B2
+        public event Action? StateChanged;
+#pragma warning restore CS0067
+
+        /// <summary><see langword="true"/> while frames are being captured.</summary>
+        public bool IsRecording { get; }
+
+        /// <summary>
+        /// Path of the file currently being written, or <see langword="null"/> when not recording or
+        /// when no frame has arrived yet — the file is created on the first frame.
+        /// </summary>
+        public string? CurrentFile { get; }
+
+        /// <summary>Time since recording started.</summary>
+        public TimeSpan Elapsed { get; }
+
+        /// <summary>Frames written across this recording run.</summary>
+        public long FrameCount { get; }
+
+        /// <summary>Bytes written across this recording run.</summary>
+        public long BytesWritten { get; }
+
+        /// <summary>
+        /// Frames dropped because the bounded channel was full. Non-zero means the disk could not
+        /// keep up; the HUD was protected rather than stalled.
+        /// </summary>
+        public long DroppedFrames { get; }
+
+        /// <summary>Folder of the current recording run, containing this run's session files.</summary>
+        public string? CurrentRunFolder { get; }
+
+        /// <summary>
+        /// Starts recording. Nothing is written until the first frame arrives.
+        /// </summary>
+        /// <param name="path">
+        /// Optional run folder. When null, a timestamped folder is created under the configured
+        /// recordings directory.
+        /// </param>
+        /// <remarks>Implemented by agent B2.</remarks>
+        public void Start(string? path = null)
+            => throw new NotImplementedException("Implemented by agent B2");
+
+        /// <summary>
+        /// Stops recording and finalises the current file — footer, summary and index patch.
+        /// Idempotent.
+        /// </summary>
+        /// <remarks>Implemented by agent B2.</remarks>
+        public void Stop()
+            => throw new NotImplementedException("Implemented by agent B2");
+
+        /// <inheritdoc />
+        /// <remarks>Implemented by agent B2.</remarks>
+        public Task StartAsync(CancellationToken cancellationToken)
+            => throw new NotImplementedException("Implemented by agent B2");
+
+        /// <inheritdoc />
+        /// <remarks>Implemented by agent B2.</remarks>
+        public Task StopAsync(CancellationToken cancellationToken)
+            => throw new NotImplementedException("Implemented by agent B2");
+
+        /// <inheritdoc />
+        /// <remarks>Implemented by agent B2.</remarks>
+        public ValueTask DisposeAsync()
+            => throw new NotImplementedException("Implemented by agent B2");
+    }
+}

--- a/R3E/Core/Recording/TelemetryRecorder.cs
+++ b/R3E/Core/Recording/TelemetryRecorder.cs
@@ -117,6 +117,18 @@ namespace R3E.Core.Recording
         /// <summary>Raised whenever any of the state below changes, so the UI can re-render.</summary>
         public event Action? StateChanged;
 
+        /// <summary>
+        /// Whether the source is currently replaying a recording rather than delivering live
+        /// telemetry. Recording a replay would write a near-duplicate of the file being played, so
+        /// frames are dropped for as long as this holds.
+        /// </summary>
+        /// <remarks>
+        /// The recorder is handed the <see cref="ISharedSource"/> registration, which resolves to
+        /// the live/replay switch rather than the live source directly - so without this guard the
+        /// recorder happily captures replayed frames.
+        /// </remarks>
+        private bool IsSourceReplaying => sharedSource is ISwitchableSharedSource { IsReplaying: true };
+
         /// <summary><see langword="true"/> while frames are being captured.</summary>
         public bool IsRecording => isRecording;
 
@@ -335,7 +347,7 @@ namespace R3E.Core.Recording
 
         private void OnRawFrameReceived(ReadOnlyMemory<byte> frame)
         {
-            if (!isRecording)
+            if (!isRecording || IsSourceReplaying)
             {
                 return;
             }
@@ -375,7 +387,7 @@ namespace R3E.Core.Recording
 
         private void OnStartLightsChanged(int value)
         {
-            if (!isRecording)
+            if (!isRecording || IsSourceReplaying)
             {
                 return;
             }

--- a/R3E/Core/Recording/TelemetryRecorder.cs
+++ b/R3E/Core/Recording/TelemetryRecorder.cs
@@ -1,4 +1,12 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using R3E.Core.Interfaces;
+using R3E.Data;
+using System.Buffers;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Channels;
 
 namespace R3E.Core.Recording
 {
@@ -21,10 +29,76 @@ namespace R3E.Core.Recording
     /// current file and opens a new one on the next frame. Files live in a per-run folder so the
     /// sessions of a stint stay together.
     /// </para>
-    /// <para>Implemented by agent B2.</para>
     /// </remarks>
     public sealed class TelemetryRecorder : IHostedService, IAsyncDisposable
     {
+        /// <summary>
+        /// Bounded channel capacity, in records. Four seconds of headroom at the 60 Hz polling rate:
+        /// enough to ride out an AV scan or a stalled write without letting the pooled backlog grow
+        /// without bound (worst case ≈ 240 × 44 KB ≈ 10 MB of rented buffers).
+        /// </summary>
+        private const int ChannelCapacity = 240;
+
+        /// <summary>Minimum interval between <see cref="StateChanged"/> notifications from the writer.</summary>
+        private static readonly TimeSpan StateNotifyInterval = TimeSpan.FromMilliseconds(500);
+
+        /// <summary>How long <see cref="Start"/> waits for a previous run to finish finalising.</summary>
+        private static readonly TimeSpan PreviousRunDrainTimeout = TimeSpan.FromSeconds(10);
+
+        // Offsets into the raw frame, resolved once so the hot path never marshals. Mirrors the
+        // pattern SharedMemoryService already uses for GameSimulationTicks.
+        private static readonly int offsetSessionType;
+        private static readonly int offsetSessionPhase;
+        private static readonly int offsetTrackId;
+        private static readonly int offsetCompletedLaps;
+        private static readonly int offsetDriverClassId;
+
+        private readonly ISharedSource sharedSource;
+        private readonly RecordingOptions options;
+        private readonly ILogger<TelemetryRecorder> logger;
+        private readonly string yaHudVersion;
+        private readonly Lock stateLock = new();
+        private readonly HashSet<int> observedClasses = [];
+        private readonly Stopwatch stopwatch = new();
+
+        private Channel<QueuedRecord>? channel;
+        private Task? runTask;
+        private volatile bool isRecording;
+        private bool subscribed;
+        private bool disposed;
+
+        // Run state. Written under stateLock on start/stop, otherwise only by the writer task.
+        private string? runFolder;
+        private string? explicitRunFolder;
+        private DateTime runStartUtc;
+        private TimeSpan finalElapsed;
+
+        private long frameCount;
+        private long bytesWrittenClosed;
+        private long droppedFrames;
+
+        // Writer-task-only state.
+        private TelemetryRecordingWriter? writer;
+        private int fileIndex;
+        private long fileStartMs;
+        private int currentSessionType;
+        private int currentTrackId;
+        private int lastSessionPhase;
+        private int lastCompletedLaps;
+        private bool fileOpenFailed;
+        private long lastNotifyMs;
+
+        static TelemetryRecorder()
+        {
+            offsetSessionType = (int)Marshal.OffsetOf<Shared>(nameof(Shared.SessionType));
+            offsetSessionPhase = (int)Marshal.OffsetOf<Shared>(nameof(Shared.SessionPhase));
+            offsetTrackId = (int)Marshal.OffsetOf<Shared>(nameof(Shared.TrackId));
+            offsetCompletedLaps = (int)Marshal.OffsetOf<Shared>(nameof(Shared.CompletedLaps));
+            offsetDriverClassId =
+                (int)Marshal.OffsetOf<DriverData>(nameof(DriverData.DriverInfo))
+                + (int)Marshal.OffsetOf<DriverInfo>(nameof(DriverInfo.ClassId));
+        }
+
         /// <summary>
         /// Creates the recorder. It stays inert until <see cref="Start"/> is called, or immediately
         /// starts when <see cref="RecordingOptions.AutoStart"/> is set.
@@ -32,41 +106,51 @@ namespace R3E.Core.Recording
         /// <param name="sharedSource">The source whose raw frames are captured.</param>
         /// <param name="options">Recording settings from configuration and launch arguments.</param>
         /// <param name="logger">Optional logger.</param>
-        /// <remarks>Implemented by agent B2.</remarks>
         public TelemetryRecorder(ISharedSource sharedSource, RecordingOptions options, ILogger<TelemetryRecorder>? logger = null)
-            => throw new NotImplementedException("Implemented by agent B2");
+        {
+            this.sharedSource = sharedSource ?? throw new ArgumentNullException(nameof(sharedSource));
+            this.options = options ?? throw new ArgumentNullException(nameof(options));
+            this.logger = logger ?? NullLogger<TelemetryRecorder>.Instance;
+            yaHudVersion = ResolveYaHudVersion();
+        }
 
         /// <summary>Raised whenever any of the state below changes, so the UI can re-render.</summary>
-#pragma warning disable CS0067 // Event is never used - raised by agent B2
         public event Action? StateChanged;
-#pragma warning restore CS0067
 
         /// <summary><see langword="true"/> while frames are being captured.</summary>
-        public bool IsRecording { get; }
+        public bool IsRecording => isRecording;
 
         /// <summary>
         /// Path of the file currently being written, or <see langword="null"/> when not recording or
         /// when no frame has arrived yet — the file is created on the first frame.
         /// </summary>
-        public string? CurrentFile { get; }
+        public string? CurrentFile => writer?.Path;
 
         /// <summary>Time since recording started.</summary>
-        public TimeSpan Elapsed { get; }
+        public TimeSpan Elapsed => isRecording ? stopwatch.Elapsed : finalElapsed;
 
         /// <summary>Frames written across this recording run.</summary>
-        public long FrameCount { get; }
+        public long FrameCount => Interlocked.Read(ref frameCount);
 
         /// <summary>Bytes written across this recording run.</summary>
-        public long BytesWritten { get; }
+        public long BytesWritten
+        {
+            get
+            {
+                var closed = Interlocked.Read(ref bytesWrittenClosed);
+                var current = writer;
+                return current is null || current.IsClosed ? closed : closed + current.BytesWritten;
+            }
+        }
 
         /// <summary>
         /// Frames dropped because the bounded channel was full. Non-zero means the disk could not
         /// keep up; the HUD was protected rather than stalled.
         /// </summary>
-        public long DroppedFrames { get; }
+        public long DroppedFrames => Interlocked.Read(ref droppedFrames);
 
         /// <summary>Folder of the current recording run, containing this run's session files.</summary>
-        public string? CurrentRunFolder { get; }
+        public string? CurrentRunFolder => runFolder;
 
         /// <summary>
         /// Starts recording. Nothing is written until the first frame arrives.
@@ -75,31 +159,597 @@ namespace R3E.Core.Recording
         /// Optional run folder. When null, a timestamped folder is created under the configured
         /// recordings directory.
         /// </param>
-        /// <remarks>Implemented by agent B2.</remarks>
         public void Start(string? path = null)
-            => throw new NotImplementedException("Implemented by agent B2");
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+
+            lock (stateLock)
+            {
+                if (isRecording)
+                {
+                    return;
+                }
+
+                WaitForPreviousRun();
+
+                explicitRunFolder = string.IsNullOrWhiteSpace(path) ? null : Path.GetFullPath(path);
+                runFolder = explicitRunFolder;
+                runStartUtc = DateTime.UtcNow;
+                finalElapsed = TimeSpan.Zero;
+                fileIndex = 0;
+                fileOpenFailed = false;
+                lastNotifyMs = 0;
+                observedClasses.Clear();
+
+                Interlocked.Exchange(ref frameCount, 0);
+                Interlocked.Exchange(ref bytesWrittenClosed, 0);
+                Interlocked.Exchange(ref droppedFrames, 0);
+
+                var bounded = new BoundedChannelOptions(ChannelCapacity)
+                {
+                    FullMode = BoundedChannelFullMode.DropWrite,
+                    SingleReader = true,
+                    SingleWriter = false,
+                };
+
+                // The drop callback is the only place a DropWrite rejection is observable: TryWrite
+                // still returns true, so without it the rented buffer would leak.
+                channel = Channel.CreateBounded<QueuedRecord>(bounded, OnItemDropped);
+
+                stopwatch.Restart();
+                isRecording = true;
+                runTask = Task.Run(WriterLoopAsync);
+
+                logger.LogInformation("Telemetry recording started; run folder resolves on the first frame");
+            }
+
+            RaiseStateChanged();
+        }
 
         /// <summary>
         /// Stops recording and finalises the current file — footer, summary and index patch.
         /// Idempotent.
         /// </summary>
-        /// <remarks>Implemented by agent B2.</remarks>
+        /// <remarks>
+        /// Returns as soon as the ingest path is detached. Finalisation completes on the background
+        /// writer task, which raises <see cref="StateChanged"/> when the file is closed; blocking here
+        /// would put a disk flush on the UI thread. <see cref="StopAsync"/> and
+        /// <see cref="DisposeAsync"/> await that task.
+        /// </remarks>
         public void Stop()
-            => throw new NotImplementedException("Implemented by agent B2");
+        {
+            lock (stateLock)
+            {
+                if (!isRecording)
+                {
+                    return;
+                }
+
+                isRecording = false;
+                finalElapsed = stopwatch.Elapsed;
+                stopwatch.Stop();
+
+                // Completing the writer half lets the loop drain what is already queued and then
+                // finalise the file; nothing is cancelled, so no captured frame is thrown away.
+                channel?.Writer.TryComplete();
+
+                logger.LogInformation(
+                    "Telemetry recording stopped after {Elapsed} with {Frames} frames ({Dropped} dropped)",
+                    finalElapsed,
+                    FrameCount,
+                    DroppedFrames);
+            }
+
+            RaiseStateChanged();
+        }
 
         /// <inheritdoc />
-        /// <remarks>Implemented by agent B2.</remarks>
         public Task StartAsync(CancellationToken cancellationToken)
-            => throw new NotImplementedException("Implemented by agent B2");
+        {
+            if (!subscribed)
+            {
+                sharedSource.RawFrameReceived += OnRawFrameReceived;
+                sharedSource.StartLightsChanged += OnStartLightsChanged;
+                subscribed = true;
+            }
+
+            if (options.AutoStart)
+            {
+                Start();
+            }
+
+            return Task.CompletedTask;
+        }
 
         /// <inheritdoc />
-        /// <remarks>Implemented by agent B2.</remarks>
-        public Task StopAsync(CancellationToken cancellationToken)
-            => throw new NotImplementedException("Implemented by agent B2");
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            Unsubscribe();
+            Stop();
+            await AwaitRunAsync().ConfigureAwait(false);
+        }
 
         /// <inheritdoc />
-        /// <remarks>Implemented by agent B2.</remarks>
-        public ValueTask DisposeAsync()
-            => throw new NotImplementedException("Implemented by agent B2");
+        public async ValueTask DisposeAsync()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            Unsubscribe();
+            Stop();
+            await AwaitRunAsync().ConfigureAwait(false);
+        }
+
+        private void Unsubscribe()
+        {
+            if (!subscribed)
+            {
+                return;
+            }
+
+            subscribed = false;
+            sharedSource.RawFrameReceived -= OnRawFrameReceived;
+            sharedSource.StartLightsChanged -= OnStartLightsChanged;
+        }
+
+        private async Task AwaitRunAsync()
+        {
+            var task = runTask;
+            if (task is null)
+            {
+                return;
+            }
+
+            try
+            {
+                await task.ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Telemetry recording writer task faulted");
+            }
+        }
+
+        private void WaitForPreviousRun()
+        {
+            var previous = runTask;
+            if (previous is null || previous.IsCompleted)
+            {
+                return;
+            }
+
+            // A stop immediately followed by a start: let the previous file finish its footer so the
+            // two runs cannot interleave writer state. Finalising is a single block flush.
+            if (!previous.Wait(PreviousRunDrainTimeout))
+            {
+                logger.LogWarning("Previous recording run did not finish finalising within {Timeout}", PreviousRunDrainTimeout);
+            }
+        }
+
+        // ---------------------------------------------------------------------------------------
+        // Ingest — runs on the polling thread. Must never block, allocate heavily, or throw.
+        // ---------------------------------------------------------------------------------------
+
+        private void OnRawFrameReceived(ReadOnlyMemory<byte> frame)
+        {
+            if (!isRecording)
+            {
+                return;
+            }
+
+            byte[]? buffer = null;
+            try
+            {
+                var span = frame.Span;
+                if (span.Length != FrameTruncation.SizeOfShared)
+                {
+                    return;
+                }
+
+                var truncated = FrameTruncation.Truncate(span, out var length);
+
+                // The event's memory is over a reused buffer, so the copy has to happen here,
+                // synchronously, before the record is handed to the writer task.
+                buffer = ArrayPool<byte>.Shared.Rent(length);
+                truncated.CopyTo(buffer);
+
+                Enqueue(new QueuedRecord(RecordingRecordType.Frame, buffer, length, 0, stopwatch.ElapsedMilliseconds));
+                buffer = null;
+            }
+            catch (Exception ex)
+            {
+                // A recorder fault must not propagate into the polling loop.
+                logger.LogError(ex, "Failed to capture a raw telemetry frame");
+            }
+            finally
+            {
+                if (buffer is not null)
+                {
+                    ArrayPool<byte>.Shared.Return(buffer);
+                }
+            }
+        }
+
+        private void OnStartLightsChanged(int value)
+        {
+            if (!isRecording)
+            {
+                return;
+            }
+
+            try
+            {
+                Enqueue(new QueuedRecord(RecordingRecordType.StartLights, null, 0, value, stopwatch.ElapsedMilliseconds));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to capture a start-light sample");
+            }
+        }
+
+        private void Enqueue(in QueuedRecord record)
+        {
+            var target = channel;
+            if (target is null || !target.Writer.TryWrite(record))
+            {
+                // Channel already completed (a concurrent Stop). Nothing will read this record.
+                OnItemDropped(record);
+            }
+        }
+
+        private void OnItemDropped(QueuedRecord record)
+        {
+            ReturnBuffer(record);
+
+            if (record.Type == RecordingRecordType.Frame)
+            {
+                Interlocked.Increment(ref droppedFrames);
+            }
+        }
+
+        private static void ReturnBuffer(in QueuedRecord record)
+        {
+            if (record.Buffer is not null)
+            {
+                ArrayPool<byte>.Shared.Return(record.Buffer);
+            }
+        }
+
+        // ---------------------------------------------------------------------------------------
+        // Writer task — owns the file, the block index and every offset read past the ingest hop.
+        // ---------------------------------------------------------------------------------------
+
+        private async Task WriterLoopAsync()
+        {
+            var reader = channel!.Reader;
+
+            try
+            {
+                while (await reader.WaitToReadAsync().ConfigureAwait(false))
+                {
+                    while (reader.TryRead(out var record))
+                    {
+                        try
+                        {
+                            Process(record);
+                        }
+                        catch (Exception ex)
+                        {
+                            logger.LogError(ex, "Failed to write a telemetry record");
+                        }
+                        finally
+                        {
+                            ReturnBuffer(record);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Telemetry recording writer loop failed");
+            }
+            finally
+            {
+                // Anything still queued after a fault must give its buffer back to the pool.
+                while (reader.TryRead(out var leftover))
+                {
+                    ReturnBuffer(leftover);
+                }
+
+                CloseCurrentFile();
+                RaiseStateChanged();
+            }
+        }
+
+        private void Process(in QueuedRecord record)
+        {
+            if (record.Type == RecordingRecordType.StartLights)
+            {
+                // Start lights sampled before the first frame have no file to land in; the header
+                // cannot exist yet, so the sample is discarded rather than opening an empty file.
+                writer?.WriteStartLights(record.StartLights, ToFileElapsedMs(record.TimestampMs));
+                return;
+            }
+
+            if (record.Buffer is null)
+            {
+                return;
+            }
+
+            var frame = record.Buffer.AsSpan(0, record.Length);
+            var sessionType = ReadInt32(frame, offsetSessionType);
+            var trackId = ReadInt32(frame, offsetTrackId);
+
+            if (writer is not null && (sessionType != currentSessionType || trackId != currentTrackId))
+            {
+                logger.LogInformation(
+                    "Session changed ({OldSession}/{OldTrack} -> {NewSession}/{NewTrack}); finalising recording file",
+                    currentSessionType,
+                    currentTrackId,
+                    sessionType,
+                    trackId);
+
+                CloseCurrentFile();
+            }
+
+            if (writer is null)
+            {
+                if (fileOpenFailed && sessionType == currentSessionType && trackId == currentTrackId)
+                {
+                    // Opening this session's file already failed; do not retry it 60 times a second.
+                    return;
+                }
+
+                if (!TryOpenFile(frame, sessionType, trackId, record.TimestampMs))
+                {
+                    return;
+                }
+            }
+
+            var elapsedMs = ToFileElapsedMs(record.TimestampMs);
+
+            writer!.WriteFrame(frame, elapsedMs);
+            Interlocked.Increment(ref frameCount);
+
+            WriteMarkers(frame, elapsedMs);
+            ObserveClasses(frame);
+            NotifyThrottled(record.TimestampMs);
+        }
+
+        private void WriteMarkers(ReadOnlySpan<byte> frame, uint elapsedMs)
+        {
+            var phase = ReadInt32(frame, offsetSessionPhase);
+            if (phase != lastSessionPhase)
+            {
+                lastSessionPhase = phase;
+                writer!.AddMarker(RecordingMarkerType.PhaseChange, phase, elapsedMs);
+            }
+
+            var completedLaps = ReadInt32(frame, offsetCompletedLaps);
+            if (completedLaps != lastCompletedLaps)
+            {
+                lastCompletedLaps = completedLaps;
+
+                if (completedLaps >= 0)
+                {
+                    writer!.AddMarker(RecordingMarkerType.LapStart, completedLaps, elapsedMs);
+                }
+            }
+        }
+
+        private void ObserveClasses(ReadOnlySpan<byte> frame)
+        {
+            var numCars = FrameTruncation.ReadNumCars(frame);
+            var driversStart = FrameTruncation.MinTruncatedLength;
+
+            for (var i = 0; i < numCars; i++)
+            {
+                var offset = driversStart + (i * FrameTruncation.DriverDataSize) + offsetDriverClassId;
+                if (offset + sizeof(int) > frame.Length)
+                {
+                    break;
+                }
+
+                var classId = BitConverter.ToInt32(frame[offset..]);
+                if (classId > 0 && observedClasses.Add(classId))
+                {
+                    writer!.ObserveClass(classId);
+                }
+            }
+        }
+
+        private bool TryOpenFile(ReadOnlySpan<byte> frame, int sessionType, int trackId, long timestampMs)
+        {
+            currentSessionType = sessionType;
+            currentTrackId = trackId;
+
+            try
+            {
+                if (!FrameTruncation.MatchesLayout(frame))
+                {
+                    logger.LogWarning(
+                        "Raw frame reports a different Shared layout than this build; the recording may not replay");
+                }
+
+                // FromFirstFrame documents a full-size frame, so rebuild the zero-filled tail once
+                // per file. One allocation per session file is not worth pooling.
+                var full = FrameTruncation.Restore(frame);
+                var header = TelemetryRecordingHeader.FromFirstFrame(full, yaHudVersion);
+
+                if (header.StartUtcTicks == 0)
+                {
+                    header.StartUtcTicks = DateTime.UtcNow.Ticks;
+                }
+
+                var folder = ResolveRunFolder(header);
+                Directory.CreateDirectory(folder);
+
+                fileIndex++;
+                var path = Path.Combine(folder, BuildFileName(fileIndex, sessionType));
+
+                writer = new TelemetryRecordingWriter(path, header, Math.Max(0.1d, options.BlockSeconds));
+                fileStartMs = timestampMs;
+                lastSessionPhase = ReadInt32(frame, offsetSessionPhase);
+                lastCompletedLaps = ReadInt32(frame, offsetCompletedLaps);
+                fileOpenFailed = false;
+                observedClasses.Clear();
+
+                logger.LogInformation("Recording session {SessionType} to {Path}", sessionType, path);
+                RaiseStateChanged();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                fileOpenFailed = true;
+                writer = null;
+                logger.LogError(ex, "Failed to open a recording file for session {SessionType}", sessionType);
+                return false;
+            }
+        }
+
+        private void CloseCurrentFile()
+        {
+            var current = writer;
+            if (current is null)
+            {
+                return;
+            }
+
+            writer = null;
+
+            try
+            {
+                current.Close();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to finalise recording file {Path}", current.Path);
+            }
+            finally
+            {
+                try
+                {
+                    Interlocked.Add(ref bytesWrittenClosed, current.BytesWritten);
+                    current.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Failed to dispose recording file {Path}", current.Path);
+                }
+            }
+        }
+
+        private string ResolveRunFolder(TelemetryRecordingHeader header)
+        {
+            if (runFolder is not null)
+            {
+                return runFolder;
+            }
+
+            // Named from the run's start time, not the first frame's, so the folder still reads as
+            // "when I pressed record"; the track slug only becomes knowable here.
+            var name = new StringBuilder(runStartUtc.ToLocalTime().ToString("yyyy-MM-dd_HH-mm"));
+            var slug = Slugify(header.TrackName);
+
+            if (slug.Length > 0)
+            {
+                name.Append('-').Append(slug);
+            }
+
+            var resolved = Path.Combine(options.ResolveDirectory(), name.ToString());
+            runFolder = resolved;
+            return resolved;
+        }
+
+        private static string BuildFileName(int index, int sessionType)
+        {
+            var session = Enum.IsDefined(typeof(Constant.Session), sessionType)
+                ? ((Constant.Session)sessionType).ToString().ToLowerInvariant()
+                : "session";
+
+            return $"{index:00}-{session}{TelemetryRecordingHeader.FileExtension}";
+        }
+
+        private static string Slugify(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return string.Empty;
+            }
+
+            var builder = new StringBuilder(value.Length);
+            foreach (var c in value)
+            {
+                if (char.IsAsciiLetterOrDigit(c))
+                {
+                    builder.Append(char.ToLowerInvariant(c));
+                }
+                else if (builder.Length > 0 && builder[^1] != '-')
+                {
+                    builder.Append('-');
+                }
+            }
+
+            return builder.ToString().Trim('-');
+        }
+
+        private uint ToFileElapsedMs(long timestampMs)
+        {
+            var delta = timestampMs - fileStartMs;
+            return delta <= 0 ? 0u : (uint)delta;
+        }
+
+        private void NotifyThrottled(long timestampMs)
+        {
+            if (timestampMs - lastNotifyMs < StateNotifyInterval.TotalMilliseconds)
+            {
+                return;
+            }
+
+            lastNotifyMs = timestampMs;
+            RaiseStateChanged();
+        }
+
+        private void RaiseStateChanged()
+        {
+            try
+            {
+                StateChanged?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "A recorder StateChanged handler threw");
+            }
+        }
+
+        private static string ResolveYaHudVersion()
+        {
+            var assembly = Assembly.GetEntryAssembly() ?? typeof(TelemetryRecorder).Assembly;
+            return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+                ?? assembly.GetName().Version?.ToString()
+                ?? "unknown";
+        }
+
+        /// <summary>
+        /// One queued record. <see cref="Buffer"/> is rented from <see cref="ArrayPool{T}.Shared"/>
+        /// by the ingest thread and returned by whoever consumes or drops the record.
+        /// </summary>
+        /// <param name="Type">Which kind of record this is.</param>
+        /// <param name="Buffer">Pooled truncated frame bytes, or null for a start-light sample.</param>
+        /// <param name="Length">Meaningful length of <paramref name="Buffer"/>; the rental may be longer.</param>
+        /// <param name="StartLights">Start-light count, for <see cref="RecordingRecordType.StartLights"/>.</param>
+        /// <param name="TimestampMs">Run-relative milliseconds captured at ingest, so writer lag cannot skew cadence.</param>
+        private readonly record struct QueuedRecord(
+            RecordingRecordType Type,
+            byte[]? Buffer,
+            int Length,
+            int StartLights,
+            long TimestampMs);
+
+        private static int ReadInt32(ReadOnlySpan<byte> frame, int offset)
+            => offset + sizeof(int) <= frame.Length ? BitConverter.ToInt32(frame[offset..]) : 0;
     }
 }

--- a/R3E/Core/Recording/TelemetryRecordingHeader.cs
+++ b/R3E/Core/Recording/TelemetryRecordingHeader.cs
@@ -1,0 +1,192 @@
+using R3E.Data;
+
+namespace R3E.Core.Recording
+{
+    /// <summary>The kind of record stored inside a recording block.</summary>
+    public enum RecordingRecordType : byte
+    {
+        /// <summary>A truncated <see cref="Shared"/> frame.</summary>
+        Frame = 0,
+
+        /// <summary>A start-light count sampled by the 400 Hz poller.</summary>
+        StartLights = 1,
+    }
+
+    /// <summary>The kind of timeline marker stored in a recording footer.</summary>
+    public enum RecordingMarkerType : byte
+    {
+        /// <summary>Session phase changed; value is the new <c>Constant.SessionPhase</c>.</summary>
+        PhaseChange = 0,
+
+        /// <summary>A new lap started; value is the completed-lap count at that point.</summary>
+        LapStart = 1,
+    }
+
+    /// <summary>A timeline marker, used for "jump to lap N" without decoding the file.</summary>
+    /// <param name="ElapsedMs">Milliseconds from the start of the recording.</param>
+    /// <param name="Type">What the marker denotes.</param>
+    /// <param name="Value">Marker-specific payload.</param>
+    public readonly record struct RecordingMarker(uint ElapsedMs, RecordingMarkerType Type, int Value);
+
+    /// <summary>One entry of the footer block index.</summary>
+    /// <param name="FirstFrameMs">Elapsed time of the first record in the block.</param>
+    /// <param name="FileOffset">Absolute byte offset of the block header in the file.</param>
+    /// <param name="FrameCount">Number of records in the block.</param>
+    public readonly record struct RecordingBlockIndexEntry(uint FirstFrameMs, long FileOffset, int FrameCount);
+
+    /// <summary>
+    /// A single record read back from a recording.
+    /// </summary>
+    /// <param name="Type">Which member is meaningful.</param>
+    /// <param name="ElapsedMs">Milliseconds from the start of the recording.</param>
+    /// <param name="Frame">
+    /// For <see cref="RecordingRecordType.Frame"/>, a full-size reconstructed raw frame of
+    /// <see cref="FrameTruncation.SizeOfShared"/> bytes. Otherwise <see langword="null"/>.
+    /// </param>
+    /// <param name="StartLights">For <see cref="RecordingRecordType.StartLights"/>, the light count.</param>
+    public readonly record struct ReplayRecord(
+        RecordingRecordType Type,
+        uint ElapsedMs,
+        byte[]? Frame,
+        int StartLights);
+
+    /// <summary>
+    /// The fixed-size header of a <c>.yhtl</c> recording: format identity, the <see cref="Shared"/>
+    /// layout the file was captured against, and the session metadata taken from the first frame.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The file is created on the <em>first frame</em>, not on <c>Start()</c>. That is what lets the
+    /// header be both complete and fixed-size — track, car and driver information only exist once a
+    /// frame has arrived.
+    /// </para>
+    /// <para>
+    /// <see cref="SizeOfShared"/> is the version guard. <see cref="Shared"/> mirrors a layout owned by
+    /// Sector3; when a field is added the size changes and an old recording would otherwise silently
+    /// misparse into plausible-looking garbage. Readers must refuse loudly on a mismatch.
+    /// </para>
+    /// <para>Implemented by agent B1.</para>
+    /// </remarks>
+    public sealed class TelemetryRecordingHeader
+    {
+        /// <summary>File extension used for recordings.</summary>
+        public const string FileExtension = ".yhtl";
+
+        /// <summary>Leading magic, ASCII "YHTL".</summary>
+        public static ReadOnlySpan<byte> Magic => "YHTL"u8;
+
+        /// <summary>Trailing magic that terminates a cleanly closed footer, ASCII "YHTX".</summary>
+        public static ReadOnlySpan<byte> FooterMagic => "YHTX"u8;
+
+        /// <summary>Format version written by this build.</summary>
+        public const ushort CurrentFormatVersion = 1;
+
+        /// <summary>Format version the file was written with.</summary>
+        public ushort FormatVersion { get; set; } = CurrentFormatVersion;
+
+        /// <summary>Reserved format flags (e.g. truncation or compression disabled).</summary>
+        public ushort Flags { get; set; }
+
+        /// <summary>Marshalled size of <see cref="Shared"/> when the file was written. Version guard.</summary>
+        public int SizeOfShared { get; set; }
+
+        /// <summary>Offset of <c>NumCars</c> within <see cref="Shared"/> when the file was written.</summary>
+        public int AllDriversOffset { get; set; }
+
+        /// <summary>Marshalled size of one <c>DriverData</c> when the file was written.</summary>
+        public int DriverDataSize { get; set; }
+
+        /// <summary>RaceRoom shared-memory major version, from the first frame.</summary>
+        public int R3EVersionMajor { get; set; }
+
+        /// <summary>RaceRoom shared-memory minor version, from the first frame.</summary>
+        public int R3EVersionMinor { get; set; }
+
+        /// <summary>YaHud version that produced the recording.</summary>
+        public string YaHudVersion { get; set; } = string.Empty;
+
+        /// <summary>UTC ticks at which the first frame was captured.</summary>
+        public long StartUtcTicks { get; set; }
+
+        /// <summary>
+        /// Absolute byte offset of the footer index, patched in on a clean close. Zero means the
+        /// application crashed and the reader must rebuild the index by scanning block headers.
+        /// </summary>
+        public long IndexOffset { get; set; }
+
+        /// <summary>Session type at the first frame (<c>Constant.Session</c>).</summary>
+        public int SessionType { get; set; }
+
+        /// <summary>Session phase at the first frame (<c>Constant.SessionPhase</c>).</summary>
+        public int SessionPhaseAtStart { get; set; }
+
+        /// <summary>Track identifier.</summary>
+        public int TrackId { get; set; }
+
+        /// <summary>Layout identifier.</summary>
+        public int LayoutId { get; set; }
+
+        /// <summary>Track name, decoded from the frame's null-terminated UTF-8 field.</summary>
+        public string TrackName { get; set; } = string.Empty;
+
+        /// <summary>Layout name, decoded from the frame's null-terminated UTF-8 field.</summary>
+        public string LayoutName { get; set; } = string.Empty;
+
+        /// <summary>Player name.</summary>
+        public string PlayerName { get; set; } = string.Empty;
+
+        /// <summary>Player car model identifier.</summary>
+        public int PlayerCarModelId { get; set; }
+
+        /// <summary>Player car name.</summary>
+        public string PlayerCarName { get; set; } = string.Empty;
+
+        /// <summary>Player class identifier.</summary>
+        public int PlayerClassId { get; set; }
+
+        /// <summary>Player class performance index.</summary>
+        public int PlayerClassPerfIndex { get; set; }
+
+        /// <summary>Driver count at the first frame. May be exceeded later; see the footer summary.</summary>
+        public int NumCarsAtStart { get; set; }
+
+        /// <summary>UTC timestamp at which the first frame was captured.</summary>
+        public DateTime StartUtc => new(StartUtcTicks, DateTimeKind.Utc);
+
+        /// <summary>
+        /// Populates the layout and metadata fields from a full-size raw frame.
+        /// </summary>
+        /// <param name="fullFrame">A full-size raw <see cref="Shared"/> frame.</param>
+        /// <param name="yaHudVersion">Version string of the running build.</param>
+        /// <returns>A header ready to be written.</returns>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public static TelemetryRecordingHeader FromFirstFrame(ReadOnlySpan<byte> fullFrame, string yaHudVersion)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>Writes the header at the current position of <paramref name="writer"/>.</summary>
+        /// <param name="writer">A little-endian binary writer positioned at the start of the file.</param>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public void Write(BinaryWriter writer)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>Reads and validates a header.</summary>
+        /// <param name="reader">A little-endian binary reader positioned at the start of the file.</param>
+        /// <returns>The parsed header.</returns>
+        /// <exception cref="InvalidDataException">
+        /// The magic, format version or <see cref="SizeOfShared"/> does not match this build.
+        /// </exception>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public static TelemetryRecordingHeader Read(BinaryReader reader)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>
+        /// Reads only the header of a recording, without loading the index or decoding any block.
+        /// This is what lets the recordings browser show metadata for a whole folder at a glance.
+        /// </summary>
+        /// <param name="path">Path to a <c>.yhtl</c> file.</param>
+        /// <returns>The parsed header.</returns>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public static TelemetryRecordingHeader ReadFrom(string path)
+            => throw new NotImplementedException("Implemented by agent B1");
+    }
+}

--- a/R3E/Core/Recording/TelemetryRecordingHeader.cs
+++ b/R3E/Core/Recording/TelemetryRecordingHeader.cs
@@ -1,4 +1,6 @@
 using R3E.Data;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace R3E.Core.Recording
 {
@@ -154,20 +156,118 @@ namespace R3E.Core.Recording
         public DateTime StartUtc => new(StartUtcTicks, DateTimeKind.Utc);
 
         /// <summary>
+        /// Absolute byte offset at which <see cref="IndexOffset"/> was last written by
+        /// <see cref="Write"/>. The writer patches that eight-byte slot on a clean close, and the
+        /// slot cannot be at a constant offset because the version string in front of it is
+        /// length-prefixed.
+        /// </summary>
+        internal long IndexOffsetPosition { get; private set; }
+
+        // Offsets into the raw frame, resolved once. Mirrors the pattern in SharedMemoryService:
+        // the layout is owned by Sector3, so it is read from the compiled struct rather than
+        // hardcoded.
+        private static readonly int versionMajorOffset = OffsetOf(nameof(Shared.VersionMajor));
+        private static readonly int versionMinorOffset = OffsetOf(nameof(Shared.VersionMinor));
+        private static readonly int trackNameOffset = OffsetOf(nameof(Shared.TrackName));
+        private static readonly int layoutNameOffset = OffsetOf(nameof(Shared.LayoutName));
+        private static readonly int trackIdOffset = OffsetOf(nameof(Shared.TrackId));
+        private static readonly int layoutIdOffset = OffsetOf(nameof(Shared.LayoutId));
+        private static readonly int sessionTypeOffset = OffsetOf(nameof(Shared.SessionType));
+        private static readonly int sessionPhaseOffset = OffsetOf(nameof(Shared.SessionPhase));
+        private static readonly int playerNameOffset = OffsetOf(nameof(Shared.PlayerName));
+        private static readonly int vehicleInfoOffset = OffsetOf(nameof(Shared.VehicleInfo));
+
+        private static readonly int carNameOffset =
+            vehicleInfoOffset + (int)Marshal.OffsetOf<DriverInfo>(nameof(DriverInfo.Name));
+        private static readonly int carModelIdOffset =
+            vehicleInfoOffset + (int)Marshal.OffsetOf<DriverInfo>(nameof(DriverInfo.ModelId));
+        private static readonly int carClassIdOffset =
+            vehicleInfoOffset + (int)Marshal.OffsetOf<DriverInfo>(nameof(DriverInfo.ClassId));
+        private static readonly int carClassPerfIndexOffset =
+            vehicleInfoOffset + (int)Marshal.OffsetOf<DriverInfo>(nameof(DriverInfo.ClassPerformanceIndex));
+
+        /// <summary>Length of the fixed <c>byte[]</c> string fields in <see cref="Shared"/>.</summary>
+        private const int SharedStringLength = 64;
+
+        private static int OffsetOf(string field) => (int)Marshal.OffsetOf<Shared>(field);
+
+        /// <summary>
         /// Populates the layout and metadata fields from a full-size raw frame.
         /// </summary>
         /// <param name="fullFrame">A full-size raw <see cref="Shared"/> frame.</param>
         /// <param name="yaHudVersion">Version string of the running build.</param>
         /// <returns>A header ready to be written.</returns>
-        /// <remarks>Implemented by agent B1.</remarks>
+        /// <exception cref="ArgumentException"><paramref name="fullFrame"/> is not a full-size frame.</exception>
         public static TelemetryRecordingHeader FromFirstFrame(ReadOnlySpan<byte> fullFrame, string yaHudVersion)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            if (fullFrame.Length < FrameTruncation.SizeOfShared)
+            {
+                throw new ArgumentException(
+                    $"Expected a full frame of {FrameTruncation.SizeOfShared} bytes but got {fullFrame.Length}.",
+                    nameof(fullFrame));
+            }
+
+            return new TelemetryRecordingHeader
+            {
+                FormatVersion = CurrentFormatVersion,
+                Flags = 0,
+                SizeOfShared = FrameTruncation.SizeOfShared,
+                AllDriversOffset = FrameTruncation.NumCarsOffset,
+                DriverDataSize = FrameTruncation.DriverDataSize,
+                R3EVersionMajor = ReadInt(fullFrame, versionMajorOffset),
+                R3EVersionMinor = ReadInt(fullFrame, versionMinorOffset),
+                YaHudVersion = yaHudVersion ?? string.Empty,
+                StartUtcTicks = DateTime.UtcNow.Ticks,
+                IndexOffset = 0,
+                SessionType = ReadInt(fullFrame, sessionTypeOffset),
+                SessionPhaseAtStart = ReadInt(fullFrame, sessionPhaseOffset),
+                TrackId = ReadInt(fullFrame, trackIdOffset),
+                LayoutId = ReadInt(fullFrame, layoutIdOffset),
+                TrackName = ReadString(fullFrame, trackNameOffset),
+                LayoutName = ReadString(fullFrame, layoutNameOffset),
+                PlayerName = ReadString(fullFrame, playerNameOffset),
+                PlayerCarModelId = ReadInt(fullFrame, carModelIdOffset),
+                PlayerCarName = ReadString(fullFrame, carNameOffset),
+                PlayerClassId = ReadInt(fullFrame, carClassIdOffset),
+                PlayerClassPerfIndex = ReadInt(fullFrame, carClassPerfIndexOffset),
+                NumCarsAtStart = FrameTruncation.ReadNumCars(fullFrame),
+            };
+        }
 
         /// <summary>Writes the header at the current position of <paramref name="writer"/>.</summary>
         /// <param name="writer">A little-endian binary writer positioned at the start of the file.</param>
-        /// <remarks>Implemented by agent B1.</remarks>
         public void Write(BinaryWriter writer)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            ArgumentNullException.ThrowIfNull(writer);
+
+            writer.Write(Magic);
+            writer.Write(FormatVersion);
+            writer.Write(Flags);
+            writer.Write(SizeOfShared);
+            writer.Write(AllDriversOffset);
+            writer.Write(DriverDataSize);
+            writer.Write(R3EVersionMajor);
+            writer.Write(R3EVersionMinor);
+            writer.Write(YaHudVersion);
+            writer.Write(StartUtcTicks);
+
+            writer.Flush();
+            IndexOffsetPosition = writer.BaseStream.Position;
+            writer.Write(IndexOffset);
+
+            writer.Write(SessionType);
+            writer.Write(SessionPhaseAtStart);
+            writer.Write(TrackId);
+            writer.Write(LayoutId);
+            writer.Write(TrackName);
+            writer.Write(LayoutName);
+            writer.Write(PlayerName);
+            writer.Write(PlayerCarModelId);
+            writer.Write(PlayerCarName);
+            writer.Write(PlayerClassId);
+            writer.Write(PlayerClassPerfIndex);
+            writer.Write(NumCarsAtStart);
+        }
 
         /// <summary>Reads and validates a header.</summary>
         /// <param name="reader">A little-endian binary reader positioned at the start of the file.</param>
@@ -175,9 +275,81 @@ namespace R3E.Core.Recording
         /// <exception cref="InvalidDataException">
         /// The magic, format version or <see cref="SizeOfShared"/> does not match this build.
         /// </exception>
-        /// <remarks>Implemented by agent B1.</remarks>
         public static TelemetryRecordingHeader Read(BinaryReader reader)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            ArgumentNullException.ThrowIfNull(reader);
+
+            var magic = reader.ReadBytes(Magic.Length);
+            if (magic.Length != Magic.Length || !magic.AsSpan().SequenceEqual(Magic))
+            {
+                throw new InvalidDataException(
+                    "Not a YaHud telemetry recording: the file does not start with the \"YHTL\" magic.");
+            }
+
+            var header = new TelemetryRecordingHeader
+            {
+                FormatVersion = reader.ReadUInt16(),
+                Flags = reader.ReadUInt16(),
+            };
+
+            if (header.FormatVersion == 0 || header.FormatVersion > CurrentFormatVersion)
+            {
+                throw new InvalidDataException(
+                    $"Recording format version {header.FormatVersion} is not supported by this build " +
+                    $"(it understands up to version {CurrentFormatVersion}).");
+            }
+
+            header.SizeOfShared = reader.ReadInt32();
+            header.AllDriversOffset = reader.ReadInt32();
+            header.DriverDataSize = reader.ReadInt32();
+
+            // The version guard. Shared mirrors a layout owned by Sector3; if it has changed since the
+            // recording was made, every frame in the file would misparse into plausible-looking
+            // garbage. Refuse loudly rather than render nonsense.
+            if (header.SizeOfShared != FrameTruncation.SizeOfShared
+                || header.AllDriversOffset != FrameTruncation.NumCarsOffset
+                || header.DriverDataSize != FrameTruncation.DriverDataSize)
+            {
+                throw new InvalidDataException(
+                    "This recording was captured against a different RaceRoom shared-memory layout and " +
+                    "cannot be replayed by this build of YaHud. " +
+                    $"Recording: sizeofShared={header.SizeOfShared}, allDriversOffset={header.AllDriversOffset}, " +
+                    $"driverDataSize={header.DriverDataSize}. " +
+                    $"This build: sizeofShared={FrameTruncation.SizeOfShared}, " +
+                    $"allDriversOffset={FrameTruncation.NumCarsOffset}, " +
+                    $"driverDataSize={FrameTruncation.DriverDataSize}.");
+            }
+
+            header.R3EVersionMajor = reader.ReadInt32();
+            header.R3EVersionMinor = reader.ReadInt32();
+            header.YaHudVersion = reader.ReadString();
+            header.StartUtcTicks = reader.ReadInt64();
+
+            reader.BaseStream.Flush();
+            header.IndexOffsetPosition = reader.BaseStream.Position;
+            header.IndexOffset = reader.ReadInt64();
+
+            header.SessionType = reader.ReadInt32();
+            header.SessionPhaseAtStart = reader.ReadInt32();
+            header.TrackId = reader.ReadInt32();
+            header.LayoutId = reader.ReadInt32();
+            header.TrackName = reader.ReadString();
+            header.LayoutName = reader.ReadString();
+            header.PlayerName = reader.ReadString();
+            header.PlayerCarModelId = reader.ReadInt32();
+            header.PlayerCarName = reader.ReadString();
+            header.PlayerClassId = reader.ReadInt32();
+            header.PlayerClassPerfIndex = reader.ReadInt32();
+            header.NumCarsAtStart = reader.ReadInt32();
+
+            if (header.StartUtcTicks < 0 || header.StartUtcTicks > DateTime.MaxValue.Ticks)
+            {
+                throw new InvalidDataException(
+                    $"Recording header carries an implausible start timestamp ({header.StartUtcTicks} ticks).");
+            }
+
+            return header;
+        }
 
         /// <summary>
         /// Reads only the header of a recording, without loading the index or decoding any block.
@@ -185,8 +357,37 @@ namespace R3E.Core.Recording
         /// </summary>
         /// <param name="path">Path to a <c>.yhtl</c> file.</param>
         /// <returns>The parsed header.</returns>
-        /// <remarks>Implemented by agent B1.</remarks>
         public static TelemetryRecordingHeader ReadFrom(string path)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            ArgumentException.ThrowIfNullOrEmpty(path);
+
+            using var stream = new FileStream(
+                path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+            try
+            {
+                return Read(reader);
+            }
+            catch (EndOfStreamException ex)
+            {
+                throw new InvalidDataException(
+                    $"\"{path}\" is truncated before the end of the recording header.", ex);
+            }
+        }
+
+        private static int ReadInt(ReadOnlySpan<byte> frame, int offset)
+            => BitConverter.ToInt32(frame[offset..]);
+
+        private static string ReadString(ReadOnlySpan<byte> frame, int offset)
+        {
+            var field = frame.Slice(offset, SharedStringLength);
+            var end = field.IndexOf((byte)0);
+            if (end < 0)
+            {
+                end = field.Length;
+            }
+
+            return Encoding.UTF8.GetString(field[..end]);
+        }
     }
 }

--- a/R3E/Core/Recording/TelemetryRecordingReader.cs
+++ b/R3E/Core/Recording/TelemetryRecordingReader.cs
@@ -1,0 +1,121 @@
+namespace R3E.Core.Recording
+{
+    /// <summary>
+    /// Reads a <c>.yhtl</c> recording back: validates the header against this build's
+    /// <c>Shared</c> layout, loads (or rebuilds) the block index, and streams records forward.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The reader prefers the footer summary and falls back to the header values when the footer is
+    /// missing — after a crash, metadata is still available, just as-of-first-frame. When
+    /// <see cref="TelemetryRecordingHeader.IndexOffset"/> is zero or the trailing magic is absent,
+    /// the index is rebuilt by walking block headers, which is a seek-only scan rather than a decode.
+    /// </para>
+    /// <para>
+    /// Reading is strictly forward. A backward seek is expressed by seeking to an earlier position,
+    /// which the reader satisfies by restarting from the block that contains it — replay's rewind
+    /// semantics live in <c>ReplayController</c>, not here.
+    /// </para>
+    /// <para>Implemented by agent B1.</para>
+    /// </remarks>
+    public sealed class TelemetryRecordingReader : IDisposable
+    {
+        /// <summary>
+        /// Opens a recording and reads its header, index and markers.
+        /// </summary>
+        /// <param name="path">Path to a <c>.yhtl</c> file.</param>
+        /// <exception cref="InvalidDataException">
+        /// The file is not a recording, or was written against a different <c>Shared</c> layout.
+        /// </exception>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public TelemetryRecordingReader(string path)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>Path of the file being read.</summary>
+        public string Path { get; } = string.Empty;
+
+        /// <summary>The validated file header.</summary>
+        public TelemetryRecordingHeader Header { get; } = new();
+
+        /// <summary>Total recorded duration.</summary>
+        public TimeSpan Duration { get; }
+
+        /// <summary>Total number of frame records in the file.</summary>
+        public long TotalFrames { get; }
+
+        /// <summary>
+        /// Highest driver count observed over the whole session, from the footer summary; falls back
+        /// to <see cref="TelemetryRecordingHeader.NumCarsAtStart"/> when the footer is missing.
+        /// </summary>
+        public int MaxNumCars { get; }
+
+        /// <summary>Every car class observed in the session, from the footer summary.</summary>
+        public IReadOnlyList<int> ClassIds { get; } = [];
+
+        /// <summary>All timeline markers, ordered by elapsed time.</summary>
+        public IReadOnlyList<RecordingMarker> Markers { get; } = [];
+
+        /// <summary>The block index, ordered by elapsed time.</summary>
+        public IReadOnlyList<RecordingBlockIndexEntry> Index { get; } = [];
+
+        /// <summary>
+        /// <see langword="true"/> when the footer was missing or damaged and the index had to be
+        /// rebuilt by scanning — i.e. the recording was cut short by a crash.
+        /// </summary>
+        public bool IndexWasRebuilt { get; }
+
+        /// <summary>Elapsed time of the record most recently returned by <see cref="ReadNext"/>.</summary>
+        public TimeSpan Position { get; }
+
+        /// <summary>
+        /// Positions the reader so that the next <see cref="ReadNext"/> returns the first record at
+        /// or after <paramref name="position"/>.
+        /// </summary>
+        /// <param name="position">Target position, clamped to <c>[0, <see cref="Duration"/>]</c>.</param>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public void SeekTo(TimeSpan position)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>Positions the reader back at the first record. Equivalent to <c>SeekTo(TimeSpan.Zero)</c>.</summary>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public void Rewind()
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>
+        /// Returns the start of the session containing <paramref name="position"/>. Because recording
+        /// splits per session, this is always <see cref="TimeSpan.Zero"/> for a well-formed file; it
+        /// exists so callers do not have to encode that assumption.
+        /// </summary>
+        /// <param name="position">A position within the recording.</param>
+        /// <returns>The session start time.</returns>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public TimeSpan SessionStartAt(TimeSpan position)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>
+        /// Finds the position at which the given lap starts, from the
+        /// <see cref="RecordingMarkerType.LapStart"/> markers.
+        /// </summary>
+        /// <param name="lap">Completed-lap count to jump to.</param>
+        /// <param name="position">Receives the start position of that lap.</param>
+        /// <returns><see langword="false"/> when no such marker exists.</returns>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public bool TryGetLapStart(int lap, out TimeSpan position)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>
+        /// Reads the next record. Frame records are returned reconstructed to full
+        /// <see cref="FrameTruncation.SizeOfShared"/> size and ready to marshal.
+        /// </summary>
+        /// <param name="record">Receives the record.</param>
+        /// <returns><see langword="false"/> at end of file.</returns>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public bool ReadNext(out ReplayRecord record)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <inheritdoc />
+        /// <remarks>Implemented by agent B1.</remarks>
+        public void Dispose()
+            => throw new NotImplementedException("Implemented by agent B1");
+    }
+}

--- a/R3E/Core/Recording/TelemetryRecordingReader.cs
+++ b/R3E/Core/Recording/TelemetryRecordingReader.cs
@@ -1,3 +1,6 @@
+using System.IO.Compression;
+using System.Text;
+
 namespace R3E.Core.Recording
 {
     /// <summary>
@@ -16,10 +19,32 @@ namespace R3E.Core.Recording
     /// which the reader satisfies by restarting from the block that contains it — replay's rewind
     /// semantics live in <c>ReplayController</c>, not here.
     /// </para>
-    /// <para>Implemented by agent B1.</para>
     /// </remarks>
     public sealed class TelemetryRecordingReader : IDisposable
     {
+        /// <summary>Bytes of a block header: compressedLen, firstFrameMs, frameCount.</summary>
+        private const int BlockHeaderSize = sizeof(int) + sizeof(uint) + sizeof(int);
+
+        /// <summary>Bytes of a record header: elapsedMs, recordType, payloadLen.</summary>
+        private const int RecordHeaderSize = sizeof(uint) + 1 + sizeof(int);
+
+        /// <summary>A decoded record's position inside the decompressed block buffer.</summary>
+        private readonly record struct BlockRecord(uint ElapsedMs, RecordingRecordType Type, int Offset, int Length);
+
+        private readonly FileStream stream;
+        private readonly BinaryReader reader;
+        private readonly long dataStart;
+        private readonly List<RecordingBlockIndexEntry> index = [];
+        private readonly List<RecordingMarker> markers = [];
+        private readonly List<int> classIds = [];
+        private readonly List<BlockRecord> blockRecords = [];
+
+        private byte[] blockBuffer = [];
+        private int loadedBlock = -1;
+        private int recordPointer;
+        private uint position;
+        private bool disposed;
+
         /// <summary>
         /// Opens a recording and reads its header, index and markers.
         /// </summary>
@@ -27,27 +52,69 @@ namespace R3E.Core.Recording
         /// <exception cref="InvalidDataException">
         /// The file is not a recording, or was written against a different <c>Shared</c> layout.
         /// </exception>
-        /// <remarks>Implemented by agent B1.</remarks>
         public TelemetryRecordingReader(string path)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            ArgumentException.ThrowIfNullOrEmpty(path);
+
+            Path = path;
+            stream = new FileStream(
+                path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete, bufferSize: 64 * 1024);
+            reader = new BinaryReader(stream, Encoding.UTF8, leaveOpen: true);
+
+            try
+            {
+                Header = TelemetryRecordingHeader.Read(reader);
+            }
+            catch (EndOfStreamException ex)
+            {
+                reader.Dispose();
+                stream.Dispose();
+                throw new InvalidDataException($"\"{path}\" is truncated before the end of the recording header.", ex);
+            }
+            catch
+            {
+                reader.Dispose();
+                stream.Dispose();
+                throw;
+            }
+
+            dataStart = stream.Position;
+
+            // Metadata defaults: the header values, which is what a crashed recording is left with.
+            MaxNumCars = Header.NumCarsAtStart;
+            if (Header.PlayerClassId != 0)
+            {
+                classIds.Add(Header.PlayerClassId);
+            }
+
+            if (!TryLoadFooter())
+            {
+                RebuildIndex();
+                IndexWasRebuilt = true;
+            }
+
+            Index = index;
+            Markers = markers;
+            ClassIds = classIds;
+        }
 
         /// <summary>Path of the file being read.</summary>
-        public string Path { get; } = string.Empty;
+        public string Path { get; }
 
         /// <summary>The validated file header.</summary>
-        public TelemetryRecordingHeader Header { get; } = new();
+        public TelemetryRecordingHeader Header { get; }
 
         /// <summary>Total recorded duration.</summary>
-        public TimeSpan Duration { get; }
+        public TimeSpan Duration { get; private set; }
 
         /// <summary>Total number of frame records in the file.</summary>
-        public long TotalFrames { get; }
+        public long TotalFrames { get; private set; }
 
         /// <summary>
         /// Highest driver count observed over the whole session, from the footer summary; falls back
         /// to <see cref="TelemetryRecordingHeader.NumCarsAtStart"/> when the footer is missing.
         /// </summary>
-        public int MaxNumCars { get; }
+        public int MaxNumCars { get; private set; }
 
         /// <summary>Every car class observed in the session, from the footer summary.</summary>
         public IReadOnlyList<int> ClassIds { get; } = [];
@@ -62,24 +129,55 @@ namespace R3E.Core.Recording
         /// <see langword="true"/> when the footer was missing or damaged and the index had to be
         /// rebuilt by scanning — i.e. the recording was cut short by a crash.
         /// </summary>
-        public bool IndexWasRebuilt { get; }
+        public bool IndexWasRebuilt { get; private set; }
 
         /// <summary>Elapsed time of the record most recently returned by <see cref="ReadNext"/>.</summary>
-        public TimeSpan Position { get; }
+        public TimeSpan Position => TimeSpan.FromMilliseconds(position);
 
         /// <summary>
         /// Positions the reader so that the next <see cref="ReadNext"/> returns the first record at
         /// or after <paramref name="position"/>.
         /// </summary>
         /// <param name="position">Target position, clamped to <c>[0, <see cref="Duration"/>]</c>.</param>
-        /// <remarks>Implemented by agent B1.</remarks>
         public void SeekTo(TimeSpan position)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+
+            var targetMs = position <= TimeSpan.Zero
+                ? 0u
+                : (uint)Math.Min(position.TotalMilliseconds, Duration.TotalMilliseconds);
+
+            if (index.Count == 0)
+            {
+                this.position = targetMs;
+                return;
+            }
+
+            // Last block whose first record is at or before the target: the target record, if it
+            // exists at all, is inside it. At most one block is decoded.
+            var block = 0;
+            for (var i = index.Count - 1; i >= 0; i--)
+            {
+                if (index[i].FirstFrameMs <= targetMs)
+                {
+                    block = i;
+                    break;
+                }
+            }
+
+            LoadBlock(block);
+
+            recordPointer = 0;
+            while (recordPointer < blockRecords.Count && blockRecords[recordPointer].ElapsedMs < targetMs)
+            {
+                recordPointer++;
+            }
+
+            this.position = targetMs;
+        }
 
         /// <summary>Positions the reader back at the first record. Equivalent to <c>SeekTo(TimeSpan.Zero)</c>.</summary>
-        /// <remarks>Implemented by agent B1.</remarks>
-        public void Rewind()
-            => throw new NotImplementedException("Implemented by agent B1");
+        public void Rewind() => SeekTo(TimeSpan.Zero);
 
         /// <summary>
         /// Returns the start of the session containing <paramref name="position"/>. Because recording
@@ -88,9 +186,7 @@ namespace R3E.Core.Recording
         /// </summary>
         /// <param name="position">A position within the recording.</param>
         /// <returns>The session start time.</returns>
-        /// <remarks>Implemented by agent B1.</remarks>
-        public TimeSpan SessionStartAt(TimeSpan position)
-            => throw new NotImplementedException("Implemented by agent B1");
+        public TimeSpan SessionStartAt(TimeSpan position) => TimeSpan.Zero;
 
         /// <summary>
         /// Finds the position at which the given lap starts, from the
@@ -99,9 +195,20 @@ namespace R3E.Core.Recording
         /// <param name="lap">Completed-lap count to jump to.</param>
         /// <param name="position">Receives the start position of that lap.</param>
         /// <returns><see langword="false"/> when no such marker exists.</returns>
-        /// <remarks>Implemented by agent B1.</remarks>
         public bool TryGetLapStart(int lap, out TimeSpan position)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            foreach (var marker in markers)
+            {
+                if (marker.Type == RecordingMarkerType.LapStart && marker.Value == lap)
+                {
+                    position = TimeSpan.FromMilliseconds(marker.ElapsedMs);
+                    return true;
+                }
+            }
+
+            position = TimeSpan.Zero;
+            return false;
+        }
 
         /// <summary>
         /// Reads the next record. Frame records are returned reconstructed to full
@@ -109,13 +216,282 @@ namespace R3E.Core.Recording
         /// </summary>
         /// <param name="record">Receives the record.</param>
         /// <returns><see langword="false"/> at end of file.</returns>
-        /// <remarks>Implemented by agent B1.</remarks>
         public bool ReadNext(out ReplayRecord record)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+
+            if (loadedBlock < 0)
+            {
+                if (index.Count == 0)
+                {
+                    record = default;
+                    return false;
+                }
+
+                LoadBlock(0);
+                recordPointer = 0;
+            }
+
+            while (recordPointer >= blockRecords.Count)
+            {
+                if (loadedBlock + 1 >= index.Count)
+                {
+                    record = default;
+                    return false;
+                }
+
+                LoadBlock(loadedBlock + 1);
+                recordPointer = 0;
+            }
+
+            var entry = blockRecords[recordPointer++];
+            position = entry.ElapsedMs;
+
+            var payload = blockBuffer.AsSpan(entry.Offset, entry.Length);
+            record = entry.Type switch
+            {
+                RecordingRecordType.Frame =>
+                    new ReplayRecord(RecordingRecordType.Frame, entry.ElapsedMs, FrameTruncation.Restore(payload), 0),
+                RecordingRecordType.StartLights =>
+                    new ReplayRecord(
+                        RecordingRecordType.StartLights,
+                        entry.ElapsedMs,
+                        null,
+                        payload.Length >= sizeof(int) ? BitConverter.ToInt32(payload) : 0),
+                _ => new ReplayRecord(entry.Type, entry.ElapsedMs, null, 0),
+            };
+
+            return true;
+        }
 
         /// <inheritdoc />
-        /// <remarks>Implemented by agent B1.</remarks>
         public void Dispose()
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            reader.Dispose();
+            stream.Dispose();
+        }
+
+        /// <summary>
+        /// Reads the footer written on a clean close. Returns <see langword="false"/> when the file
+        /// was cut short, which sends the caller down the rebuild-by-scanning path.
+        /// </summary>
+        private bool TryLoadFooter()
+        {
+            if (Header.IndexOffset <= dataStart || Header.IndexOffset >= stream.Length)
+            {
+                return false;
+            }
+
+            try
+            {
+                // The trailing magic is the proof that the footer was written in full.
+                stream.Position = stream.Length - TelemetryRecordingHeader.FooterMagic.Length;
+                var trailer = reader.ReadBytes(TelemetryRecordingHeader.FooterMagic.Length);
+                if (!trailer.AsSpan().SequenceEqual(TelemetryRecordingHeader.FooterMagic))
+                {
+                    return false;
+                }
+
+                stream.Position = Header.IndexOffset;
+
+                var entryCount = reader.ReadInt32();
+                if (entryCount < 0 || entryCount > (stream.Length - Header.IndexOffset) / 4)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < entryCount; i++)
+                {
+                    index.Add(new RecordingBlockIndexEntry(
+                        reader.ReadUInt32(), reader.ReadInt64(), reader.ReadInt32()));
+                }
+
+                var markerCount = reader.ReadInt32();
+                if (markerCount < 0 || markerCount > (stream.Length - stream.Position) / 4)
+                {
+                    return false;
+                }
+
+                for (var i = 0; i < markerCount; i++)
+                {
+                    markers.Add(new RecordingMarker(
+                        reader.ReadUInt32(), (RecordingMarkerType)reader.ReadByte(), reader.ReadInt32()));
+                }
+
+                TotalFrames = reader.ReadInt64();
+                Duration = TimeSpan.FromMilliseconds(reader.ReadUInt32());
+                MaxNumCars = reader.ReadInt32();
+
+                var classCount = reader.ReadInt32();
+                if (classCount < 0 || classCount > (stream.Length - stream.Position) / 4)
+                {
+                    return false;
+                }
+
+                classIds.Clear();
+                for (var i = 0; i < classCount; i++)
+                {
+                    classIds.Add(reader.ReadInt32());
+                }
+
+                return true;
+            }
+            catch (Exception ex) when (ex is EndOfStreamException or IOException or OverflowException)
+            {
+                index.Clear();
+                markers.Clear();
+                classIds.Clear();
+                if (Header.PlayerClassId != 0)
+                {
+                    classIds.Add(Header.PlayerClassId);
+                }
+
+                MaxNumCars = Header.NumCarsAtStart;
+                TotalFrames = 0;
+                Duration = TimeSpan.Zero;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Rebuilds the block index by walking block headers. Each block header carries its own
+        /// compressed length, so this is a seek-only scan rather than a decode — a session killed
+        /// mid-write is still readable.
+        /// </summary>
+        private void RebuildIndex()
+        {
+            index.Clear();
+            markers.Clear();
+
+            var offset = dataStart;
+            var length = stream.Length;
+            long recordCount = 0;
+
+            while (offset + BlockHeaderSize <= length)
+            {
+                stream.Position = offset;
+
+                int compressedLength;
+                uint firstFrameMs;
+                int frameCount;
+                try
+                {
+                    compressedLength = reader.ReadInt32();
+                    firstFrameMs = reader.ReadUInt32();
+                    frameCount = reader.ReadInt32();
+                }
+                catch (EndOfStreamException)
+                {
+                    break;
+                }
+
+                // A partially written block, or the footer we ran into, ends the walk. Blocks are
+                // ordered by elapsed time, so a backwards step means we are no longer reading blocks
+                // — which is what the start of an intact footer looks like when only the index-offset
+                // patch is missing.
+                if (compressedLength <= 0
+                    || frameCount <= 0
+                    || offset + BlockHeaderSize + compressedLength > length
+                    || (index.Count > 0 && firstFrameMs < index[^1].FirstFrameMs))
+                {
+                    break;
+                }
+
+                index.Add(new RecordingBlockIndexEntry(firstFrameMs, offset, frameCount));
+                recordCount += frameCount;
+                offset += BlockHeaderSize + compressedLength;
+            }
+
+            // Duration needs the elapsed time of the last record, which only the block itself holds.
+            // Decoding one block is cheap and is what makes a crashed recording report a sensible
+            // length instead of the start of its final block. It also confirms the last entry really
+            // was a block: anything the scan mistook for one decodes to nothing and is dropped.
+            while (index.Count > 0)
+            {
+                var last = index.Count - 1;
+                var decoded = false;
+                try
+                {
+                    LoadBlock(last);
+                    decoded = blockRecords.Count > 0;
+                }
+                catch (Exception ex) when (ex is InvalidDataException or EndOfStreamException or IOException)
+                {
+                    decoded = false;
+                }
+
+                if (decoded)
+                {
+                    Duration = TimeSpan.FromMilliseconds(blockRecords[^1].ElapsedMs);
+                    break;
+                }
+
+                recordCount -= index[last].FrameCount;
+                index.RemoveAt(last);
+                loadedBlock = -1;
+            }
+
+            TotalFrames = Math.Max(recordCount, 0);
+            loadedBlock = -1;
+            recordPointer = 0;
+            blockRecords.Clear();
+        }
+
+        private void LoadBlock(int blockIndex)
+        {
+            if (loadedBlock == blockIndex)
+            {
+                return;
+            }
+
+            var entry = index[blockIndex];
+            stream.Position = entry.FileOffset;
+
+            var compressedLength = reader.ReadInt32();
+            _ = reader.ReadUInt32();
+            _ = reader.ReadInt32();
+
+            var compressed = reader.ReadBytes(compressedLength);
+            if (compressed.Length != compressedLength)
+            {
+                throw new InvalidDataException(
+                    $"Block {blockIndex} of \"{Path}\" is truncated at byte {entry.FileOffset}.");
+            }
+
+            using var source = new MemoryStream(compressed, writable: false);
+            using var brotli = new BrotliStream(source, CompressionMode.Decompress);
+            using var decoded = new MemoryStream(compressedLength * 4);
+            brotli.CopyTo(decoded);
+
+            blockBuffer = decoded.GetBuffer();
+            var decodedLength = (int)decoded.Length;
+
+            blockRecords.Clear();
+            var cursor = 0;
+            while (cursor + RecordHeaderSize <= decodedLength)
+            {
+                var elapsedMs = BitConverter.ToUInt32(blockBuffer, cursor);
+                var type = (RecordingRecordType)blockBuffer[cursor + sizeof(uint)];
+                var payloadLength = BitConverter.ToInt32(blockBuffer, cursor + sizeof(uint) + 1);
+                cursor += RecordHeaderSize;
+
+                if (payloadLength < 0 || cursor + payloadLength > decodedLength)
+                {
+                    break;
+                }
+
+                blockRecords.Add(new BlockRecord(elapsedMs, type, cursor, payloadLength));
+                cursor += payloadLength;
+            }
+
+            loadedBlock = blockIndex;
+            recordPointer = 0;
+        }
     }
 }

--- a/R3E/Core/Recording/TelemetryRecordingReader.cs
+++ b/R3E/Core/Recording/TelemetryRecordingReader.cs
@@ -1,4 +1,4 @@
-using System.IO.Compression;
+﻿using System.IO.Compression;
 using System.Text;
 
 namespace R3E.Core.Recording
@@ -285,7 +285,7 @@ namespace R3E.Core.Recording
         {
             if (Header.IndexOffset <= dataStart || Header.IndexOffset >= stream.Length)
             {
-                return false;
+                return DiscardFooterState();
             }
 
             try
@@ -295,7 +295,7 @@ namespace R3E.Core.Recording
                 var trailer = reader.ReadBytes(TelemetryRecordingHeader.FooterMagic.Length);
                 if (!trailer.AsSpan().SequenceEqual(TelemetryRecordingHeader.FooterMagic))
                 {
-                    return false;
+                    return DiscardFooterState();
                 }
 
                 stream.Position = Header.IndexOffset;
@@ -303,7 +303,7 @@ namespace R3E.Core.Recording
                 var entryCount = reader.ReadInt32();
                 if (entryCount < 0 || entryCount > (stream.Length - Header.IndexOffset) / 4)
                 {
-                    return false;
+                    return DiscardFooterState();
                 }
 
                 for (var i = 0; i < entryCount; i++)
@@ -315,7 +315,7 @@ namespace R3E.Core.Recording
                 var markerCount = reader.ReadInt32();
                 if (markerCount < 0 || markerCount > (stream.Length - stream.Position) / 4)
                 {
-                    return false;
+                    return DiscardFooterState();
                 }
 
                 for (var i = 0; i < markerCount; i++)
@@ -331,7 +331,7 @@ namespace R3E.Core.Recording
                 var classCount = reader.ReadInt32();
                 if (classCount < 0 || classCount > (stream.Length - stream.Position) / 4)
                 {
-                    return false;
+                    return DiscardFooterState();
                 }
 
                 classIds.Clear();
@@ -344,19 +344,35 @@ namespace R3E.Core.Recording
             }
             catch (Exception ex) when (ex is EndOfStreamException or IOException or OverflowException)
             {
-                index.Clear();
-                markers.Clear();
-                classIds.Clear();
-                if (Header.PlayerClassId != 0)
-                {
-                    classIds.Add(Header.PlayerClassId);
-                }
-
-                MaxNumCars = Header.NumCarsAtStart;
-                TotalFrames = 0;
-                Duration = TimeSpan.Zero;
-                return false;
+                return DiscardFooterState();
             }
+        }
+
+        /// <summary>
+        /// Drops anything a partially-read footer left behind and restores the header-derived
+        /// defaults, then reports failure so the caller rebuilds the index by scanning.
+        /// </summary>
+        /// <remarks>
+        /// Every footer bail routes through here. The bounds checks sit between the index, marker
+        /// and class sections, so failing a later one would otherwise leave the earlier sections
+        /// populated from a footer already known to be damaged — and <see cref="RebuildIndex"/>
+        /// clears the index and markers but not the class list, so those stale entries would
+        /// survive into a rebuilt file.
+        /// </remarks>
+        private bool DiscardFooterState()
+        {
+            index.Clear();
+            markers.Clear();
+            classIds.Clear();
+            if (Header.PlayerClassId != 0)
+            {
+                classIds.Add(Header.PlayerClassId);
+            }
+
+            MaxNumCars = Header.NumCarsAtStart;
+            TotalFrames = 0;
+            Duration = TimeSpan.Zero;
+            return false;
         }
 
         /// <summary>

--- a/R3E/Core/Recording/TelemetryRecordingWriter.cs
+++ b/R3E/Core/Recording/TelemetryRecordingWriter.cs
@@ -1,3 +1,6 @@
+using System.IO.Compression;
+using System.Text;
+
 namespace R3E.Core.Recording
 {
     /// <summary>
@@ -20,12 +23,34 @@ namespace R3E.Core.Recording
     /// <see cref="BlockSeconds"/>. Disposing flushes the pending block, appends the footer and
     /// patches <c>indexOffset</c> in the header.
     /// </para>
-    /// <para>Implemented by agent B1.</para>
     /// </remarks>
     public sealed class TelemetryRecordingWriter : IDisposable, IAsyncDisposable
     {
         /// <summary>Default compression block duration, in seconds.</summary>
         public const double DefaultBlockSeconds = 3d;
+
+        /// <summary>Smallest accepted block duration, in seconds.</summary>
+        private const double MinBlockSeconds = 0.1d;
+
+        /// <summary>Largest accepted block duration, in seconds.</summary>
+        private const double MaxBlockSeconds = 600d;
+
+        private readonly FileStream stream;
+        private readonly BinaryWriter writer;
+        private readonly MemoryStream block = new();
+        private readonly List<RecordingBlockIndexEntry> index = [];
+        private readonly List<RecordingMarker> markers = [];
+        private readonly SortedSet<int> classIds = [];
+        private readonly uint blockSpanMs;
+
+        private bool blockOpen;
+        private uint blockFirstMs;
+        private int blockRecordCount;
+        private long frameCount;
+        private uint durationMs;
+        private int maxNumCars;
+        private bool closed;
+        private bool disposed;
 
         /// <summary>
         /// Creates the file and writes the header.
@@ -37,42 +62,97 @@ namespace R3E.Core.Recording
         /// but a worse compression ratio; larger blocks compress better but waste more decode per
         /// seek.
         /// </param>
-        /// <remarks>Implemented by agent B1.</remarks>
         public TelemetryRecordingWriter(string path, TelemetryRecordingHeader header, double blockSeconds = DefaultBlockSeconds)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            ArgumentException.ThrowIfNullOrEmpty(path);
+            ArgumentNullException.ThrowIfNull(header);
+
+            if (double.IsNaN(blockSeconds) || blockSeconds < MinBlockSeconds || blockSeconds > MaxBlockSeconds)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(blockSeconds),
+                    blockSeconds,
+                    $"Block duration must be between {MinBlockSeconds} and {MaxBlockSeconds} seconds.");
+            }
+
+            Path = path;
+            Header = header;
+            BlockSeconds = blockSeconds;
+            blockSpanMs = (uint)Math.Max(1d, Math.Round(blockSeconds * 1000d));
+
+            var folder = System.IO.Path.GetDirectoryName(System.IO.Path.GetFullPath(path));
+            if (!string.IsNullOrEmpty(folder))
+            {
+                Directory.CreateDirectory(folder);
+            }
+
+            // The index offset is patched in place on a clean close, so the stream must stay seekable
+            // and readers must be able to open the file while it is still being written.
+            stream = new FileStream(
+                path, FileMode.Create, FileAccess.ReadWrite, FileShare.Read, bufferSize: 64 * 1024);
+            writer = new BinaryWriter(stream, Encoding.UTF8, leaveOpen: true);
+
+            header.IndexOffset = 0;
+            header.Write(writer);
+            writer.Flush();
+
+            if (header.PlayerClassId != 0)
+            {
+                classIds.Add(header.PlayerClassId);
+            }
+
+            maxNumCars = header.NumCarsAtStart;
+        }
 
         /// <summary>Path of the file being written.</summary>
-        public string Path { get; } = string.Empty;
+        public string Path { get; }
 
         /// <summary>Header written at the start of the file.</summary>
-        public TelemetryRecordingHeader Header { get; } = new();
+        public TelemetryRecordingHeader Header { get; }
 
         /// <summary>Compression block duration, in seconds.</summary>
         public double BlockSeconds { get; }
 
         /// <summary>Number of frame records written so far.</summary>
-        public long FrameCount { get; }
+        public long FrameCount => frameCount;
 
         /// <summary>Bytes flushed to disk so far.</summary>
-        public long BytesWritten { get; }
+        public long BytesWritten => stream.Length;
 
         /// <summary>Elapsed time of the most recent record written.</summary>
-        public uint DurationMs { get; }
+        public uint DurationMs => durationMs;
 
         /// <summary>Highest driver count observed so far; goes into the footer summary.</summary>
-        public int MaxNumCars { get; }
+        public int MaxNumCars => maxNumCars;
 
         /// <summary><see langword="true"/> once the footer has been written and the file closed.</summary>
-        public bool IsClosed { get; }
+        public bool IsClosed => closed;
 
         /// <summary>
         /// Appends a truncated frame.
         /// </summary>
         /// <param name="truncated">Truncated frame bytes, as produced by <see cref="FrameTruncation.Truncate"/>.</param>
         /// <param name="elapsedMs">Milliseconds since the first frame of this file.</param>
-        /// <remarks>Implemented by agent B1.</remarks>
         public void WriteFrame(ReadOnlySpan<byte> truncated, uint elapsedMs)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            if (truncated.Length < FrameTruncation.MinTruncatedLength
+                || truncated.Length > FrameTruncation.SizeOfShared)
+            {
+                throw new ArgumentException(
+                    $"Truncated frame length {truncated.Length} is outside " +
+                    $"[{FrameTruncation.MinTruncatedLength}, {FrameTruncation.SizeOfShared}].",
+                    nameof(truncated));
+            }
+
+            Append(RecordingRecordType.Frame, truncated, elapsedMs);
+            frameCount++;
+
+            var numCars = FrameTruncation.ReadNumCars(truncated);
+            if (numCars > maxNumCars)
+            {
+                maxNumCars = numCars;
+            }
+        }
 
         /// <summary>
         /// Appends a start-light sample. Only raised on Windows; recordings captured on Linux contain
@@ -80,9 +160,12 @@ namespace R3E.Core.Recording
         /// </summary>
         /// <param name="value">The new start-light count.</param>
         /// <param name="elapsedMs">Milliseconds since the first frame of this file.</param>
-        /// <remarks>Implemented by agent B1.</remarks>
         public void WriteStartLights(int value, uint elapsedMs)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            Span<byte> payload = stackalloc byte[sizeof(int)];
+            BitConverter.TryWriteBytes(payload, value);
+            Append(RecordingRecordType.StartLights, payload, elapsedMs);
+        }
 
         /// <summary>
         /// Records a timeline marker in the footer. Markers make "jump to lap N" cheap.
@@ -90,35 +173,174 @@ namespace R3E.Core.Recording
         /// <param name="type">What the marker denotes.</param>
         /// <param name="value">Marker-specific payload.</param>
         /// <param name="elapsedMs">Milliseconds since the first frame of this file.</param>
-        /// <remarks>Implemented by agent B1.</remarks>
         public void AddMarker(RecordingMarkerType type, int value, uint elapsedMs)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            ThrowIfClosed();
+            markers.Add(new RecordingMarker(elapsedMs, type, value));
+        }
 
         /// <summary>
         /// Notes a car class observed in this session. The footer carries the full observed set,
         /// because a multi-class field is not knowable from the first frame alone.
         /// </summary>
         /// <param name="classId">The class identifier.</param>
-        /// <remarks>Implemented by agent B1.</remarks>
         public void ObserveClass(int classId)
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            ThrowIfClosed();
+            classIds.Add(classId);
+        }
 
         /// <summary>
         /// Flushes the pending block, writes the footer and summary, and patches
         /// <see cref="TelemetryRecordingHeader.IndexOffset"/>. Idempotent.
         /// </summary>
-        /// <remarks>Implemented by agent B1.</remarks>
         public void Close()
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            if (closed)
+            {
+                return;
+            }
+
+            closed = true;
+
+            FlushBlock();
+
+            var indexOffset = stream.Position;
+
+            writer.Write(index.Count);
+            foreach (var entry in index)
+            {
+                writer.Write(entry.FirstFrameMs);
+                writer.Write(entry.FileOffset);
+                writer.Write(entry.FrameCount);
+            }
+
+            markers.Sort(static (a, b) => a.ElapsedMs.CompareTo(b.ElapsedMs));
+            writer.Write(markers.Count);
+            foreach (var marker in markers)
+            {
+                writer.Write(marker.ElapsedMs);
+                writer.Write((byte)marker.Type);
+                writer.Write(marker.Value);
+            }
+
+            writer.Write(frameCount);
+            writer.Write(durationMs);
+            writer.Write(maxNumCars);
+            writer.Write(classIds.Count);
+            foreach (var classId in classIds)
+            {
+                writer.Write(classId);
+            }
+
+            writer.Write(TelemetryRecordingHeader.FooterMagic);
+            writer.Flush();
+
+            // Patch the header last: until this lands the file reads as "crashed" and the reader
+            // rebuilds the index by scanning, which is exactly the behaviour we want mid-write.
+            stream.Position = Header.IndexOffsetPosition;
+            writer.Write(indexOffset);
+            writer.Flush();
+            stream.Flush(flushToDisk: true);
+            Header.IndexOffset = indexOffset;
+        }
 
         /// <inheritdoc />
-        /// <remarks>Implemented by agent B1.</remarks>
         public void Dispose()
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+
+            try
+            {
+                Close();
+            }
+            finally
+            {
+                writer.Dispose();
+                stream.Dispose();
+                block.Dispose();
+            }
+        }
 
         /// <inheritdoc />
-        /// <remarks>Implemented by agent B1.</remarks>
         public ValueTask DisposeAsync()
-            => throw new NotImplementedException("Implemented by agent B1");
+        {
+            Dispose();
+            return ValueTask.CompletedTask;
+        }
+
+        private void Append(RecordingRecordType type, ReadOnlySpan<byte> payload, uint elapsedMs)
+        {
+            ThrowIfClosed();
+
+            if (!blockOpen)
+            {
+                blockFirstMs = elapsedMs;
+                blockOpen = true;
+            }
+            else if (elapsedMs - blockFirstMs >= blockSpanMs)
+            {
+                FlushBlock();
+                blockFirstMs = elapsedMs;
+                blockOpen = true;
+            }
+
+            Span<byte> prefix = stackalloc byte[sizeof(uint) + 1 + sizeof(int)];
+            BitConverter.TryWriteBytes(prefix, elapsedMs);
+            prefix[sizeof(uint)] = (byte)type;
+            BitConverter.TryWriteBytes(prefix[(sizeof(uint) + 1)..], payload.Length);
+
+            block.Write(prefix);
+            block.Write(payload);
+            blockRecordCount++;
+
+            if (elapsedMs > durationMs)
+            {
+                durationMs = elapsedMs;
+            }
+        }
+
+        private void FlushBlock()
+        {
+            if (!blockOpen || blockRecordCount == 0)
+            {
+                blockOpen = false;
+                block.SetLength(0);
+                blockRecordCount = 0;
+                return;
+            }
+
+            using var compressed = new MemoryStream();
+            using (var brotli = new BrotliStream(compressed, CompressionLevel.Optimal, leaveOpen: true))
+            {
+                brotli.Write(block.GetBuffer(), 0, (int)block.Length);
+            }
+
+            var offset = stream.Position;
+            writer.Write((int)compressed.Length);
+            writer.Write(blockFirstMs);
+            writer.Write(blockRecordCount);
+            writer.Write(compressed.GetBuffer(), 0, (int)compressed.Length);
+            writer.Flush();
+
+            index.Add(new RecordingBlockIndexEntry(blockFirstMs, offset, blockRecordCount));
+
+            block.SetLength(0);
+            blockRecordCount = 0;
+            blockOpen = false;
+        }
+
+        private void ThrowIfClosed()
+        {
+            if (closed)
+            {
+                throw new InvalidOperationException($"Recording \"{Path}\" has already been closed.");
+            }
+        }
     }
 }

--- a/R3E/Core/Recording/TelemetryRecordingWriter.cs
+++ b/R3E/Core/Recording/TelemetryRecordingWriter.cs
@@ -1,0 +1,124 @@
+namespace R3E.Core.Recording
+{
+    /// <summary>
+    /// Writes a single <c>.yhtl</c> recording: header, Brotli-compressed blocks, and a footer
+    /// carrying the block index, the markers and the final summary.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// One writer instance owns exactly one file, which corresponds to exactly one session — the
+    /// recorder finalises and replaces the writer when the session changes, so file start is always
+    /// session start.
+    /// </para>
+    /// <para>
+    /// The writer is constructed with a fully populated header because the file is created on the
+    /// first frame: the caller marshals that one frame, builds the header from it, and hands both to
+    /// the writer.
+    /// </para>
+    /// <para>
+    /// Records accumulate into an in-memory block; a block is flushed once it spans
+    /// <see cref="BlockSeconds"/>. Disposing flushes the pending block, appends the footer and
+    /// patches <c>indexOffset</c> in the header.
+    /// </para>
+    /// <para>Implemented by agent B1.</para>
+    /// </remarks>
+    public sealed class TelemetryRecordingWriter : IDisposable, IAsyncDisposable
+    {
+        /// <summary>Default compression block duration, in seconds.</summary>
+        public const double DefaultBlockSeconds = 3d;
+
+        /// <summary>
+        /// Creates the file and writes the header.
+        /// </summary>
+        /// <param name="path">Destination path; the containing folder is created if needed.</param>
+        /// <param name="header">Header built from the first frame of this session.</param>
+        /// <param name="blockSeconds">
+        /// Compression block duration. Smaller blocks give finer seek granularity and a larger index
+        /// but a worse compression ratio; larger blocks compress better but waste more decode per
+        /// seek.
+        /// </param>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public TelemetryRecordingWriter(string path, TelemetryRecordingHeader header, double blockSeconds = DefaultBlockSeconds)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>Path of the file being written.</summary>
+        public string Path { get; } = string.Empty;
+
+        /// <summary>Header written at the start of the file.</summary>
+        public TelemetryRecordingHeader Header { get; } = new();
+
+        /// <summary>Compression block duration, in seconds.</summary>
+        public double BlockSeconds { get; }
+
+        /// <summary>Number of frame records written so far.</summary>
+        public long FrameCount { get; }
+
+        /// <summary>Bytes flushed to disk so far.</summary>
+        public long BytesWritten { get; }
+
+        /// <summary>Elapsed time of the most recent record written.</summary>
+        public uint DurationMs { get; }
+
+        /// <summary>Highest driver count observed so far; goes into the footer summary.</summary>
+        public int MaxNumCars { get; }
+
+        /// <summary><see langword="true"/> once the footer has been written and the file closed.</summary>
+        public bool IsClosed { get; }
+
+        /// <summary>
+        /// Appends a truncated frame.
+        /// </summary>
+        /// <param name="truncated">Truncated frame bytes, as produced by <see cref="FrameTruncation.Truncate"/>.</param>
+        /// <param name="elapsedMs">Milliseconds since the first frame of this file.</param>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public void WriteFrame(ReadOnlySpan<byte> truncated, uint elapsedMs)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>
+        /// Appends a start-light sample. Only raised on Windows; recordings captured on Linux contain
+        /// no start-light records.
+        /// </summary>
+        /// <param name="value">The new start-light count.</param>
+        /// <param name="elapsedMs">Milliseconds since the first frame of this file.</param>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public void WriteStartLights(int value, uint elapsedMs)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>
+        /// Records a timeline marker in the footer. Markers make "jump to lap N" cheap.
+        /// </summary>
+        /// <param name="type">What the marker denotes.</param>
+        /// <param name="value">Marker-specific payload.</param>
+        /// <param name="elapsedMs">Milliseconds since the first frame of this file.</param>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public void AddMarker(RecordingMarkerType type, int value, uint elapsedMs)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>
+        /// Notes a car class observed in this session. The footer carries the full observed set,
+        /// because a multi-class field is not knowable from the first frame alone.
+        /// </summary>
+        /// <param name="classId">The class identifier.</param>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public void ObserveClass(int classId)
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <summary>
+        /// Flushes the pending block, writes the footer and summary, and patches
+        /// <see cref="TelemetryRecordingHeader.IndexOffset"/>. Idempotent.
+        /// </summary>
+        /// <remarks>Implemented by agent B1.</remarks>
+        public void Close()
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <inheritdoc />
+        /// <remarks>Implemented by agent B1.</remarks>
+        public void Dispose()
+            => throw new NotImplementedException("Implemented by agent B1");
+
+        /// <inheritdoc />
+        /// <remarks>Implemented by agent B1.</remarks>
+        public ValueTask DisposeAsync()
+            => throw new NotImplementedException("Implemented by agent B1");
+    }
+}

--- a/R3E/Core/Replay/FileSharedSource.cs
+++ b/R3E/Core/Replay/FileSharedSource.cs
@@ -1,0 +1,101 @@
+using R3E.Core.Interfaces;
+using R3E.Core.Recording;
+using R3E.Data;
+
+namespace R3E.Core.Replay
+{
+    /// <summary>
+    /// An <see cref="ISharedSource"/> backed by a recording file rather than by the game.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Wraps a <see cref="TelemetryRecordingReader"/>, reconstructs each frame to full size, marshals
+    /// it with the same <c>SharedMarshaller</c> the live sources use, and raises
+    /// <see cref="DataUpdated"/>. Everything above <see cref="ISharedSource"/> is unchanged and
+    /// unaware it is being replayed.
+    /// </para>
+    /// <para>
+    /// This type does not own pacing policy — <see cref="ReplayController"/> drives it, either at
+    /// real-time cadence or as fast as the pipeline can consume during a catch-up.
+    /// </para>
+    /// <para>Implemented by agent B3.</para>
+    /// </remarks>
+    public sealed class FileSharedSource : ISharedSource, IDisposable
+    {
+        /// <inheritdoc />
+#pragma warning disable CS0067 // Events are never used - raised by agent B3
+        public event Action<Shared>? DataUpdated;
+
+        /// <inheritdoc />
+        public event Action<ReadOnlyMemory<byte>>? RawFrameReceived;
+
+        /// <inheritdoc />
+        public event Action<int>? StartLightsChanged;
+#pragma warning restore CS0067
+
+        /// <inheritdoc />
+        public Shared Data { get; } = new();
+
+        /// <summary>Path of the loaded recording, or <see langword="null"/> when nothing is loaded.</summary>
+        public string? CurrentFile { get; }
+
+        /// <summary>The underlying reader, or <see langword="null"/> when nothing is loaded.</summary>
+        public TelemetryRecordingReader? Reader { get; }
+
+        /// <summary>Elapsed position of the most recently emitted record.</summary>
+        public TimeSpan Position { get; }
+
+        /// <summary>Total duration of the loaded recording.</summary>
+        public TimeSpan Duration { get; }
+
+        /// <summary><see langword="true"/> once every record has been emitted.</summary>
+        public bool IsAtEnd { get; }
+
+        /// <summary>
+        /// Opens a recording, replacing anything already loaded.
+        /// </summary>
+        /// <param name="path">Path to a <c>.yhtl</c> file.</param>
+        /// <exception cref="InvalidDataException">The file was written against a different layout.</exception>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void Load(string path)
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <summary>Closes the loaded recording and releases the reader.</summary>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void Unload()
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <summary>
+        /// Emits the next record — marshalling and raising the matching event. This is the pump step
+        /// the controller calls; it never sleeps.
+        /// </summary>
+        /// <returns><see langword="false"/> at end of file.</returns>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public bool EmitNext()
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <summary>
+        /// Returns the elapsed position of the next record without emitting it, so the pump can
+        /// decide how long to wait.
+        /// </summary>
+        /// <param name="position">Receives the position of the next record.</param>
+        /// <returns><see langword="false"/> at end of file.</returns>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public bool TryPeekNext(out TimeSpan position)
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <summary>
+        /// Repositions the reader without emitting anything. Used by the controller's backward-seek
+        /// path, which rewinds to the start and then catches up forward.
+        /// </summary>
+        /// <param name="position">Target position, clamped to <c>[0, <see cref="Duration"/>]</c>.</param>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void SeekTo(TimeSpan position)
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <inheritdoc />
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void Dispose()
+            => throw new NotImplementedException("Implemented by agent B3");
+    }
+}

--- a/R3E/Core/Replay/FileSharedSource.cs
+++ b/R3E/Core/Replay/FileSharedSource.cs
@@ -1,5 +1,7 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using R3E.Core.Interfaces;
 using R3E.Core.Recording;
+using R3E.Core.SharedMemory;
 using R3E.Data;
 
 namespace R3E.Core.Replay
@@ -18,12 +20,40 @@ namespace R3E.Core.Replay
     /// This type does not own pacing policy — <see cref="ReplayController"/> drives it, either at
     /// real-time cadence or as fast as the pipeline can consume during a catch-up.
     /// </para>
-    /// <para>Implemented by agent B3.</para>
+    /// <para>
+    /// Threading: every member except <see cref="Load"/> and <see cref="Unload"/> is called from the
+    /// controller's pump thread only. The controller stops the pump before loading or unloading, so
+    /// this type needs no internal locking on the hot path.
+    /// </para>
     /// </remarks>
     public sealed class FileSharedSource : ISharedSource, IDisposable
     {
+        private readonly ILogger<FileSharedSource> logger;
+
+        private TelemetryRecordingReader? reader;
+        private Shared data;
+
+        /// <summary>
+        /// One-record lookahead. <see cref="TelemetryRecordingReader"/> exposes no peek, so the
+        /// record is read eagerly and held until <see cref="EmitNext"/> consumes it. Invalidated by
+        /// every reposition.
+        /// </summary>
+        private ReplayRecord pending;
+        private bool hasPending;
+        private bool exhausted;
+
+        private TimeSpan position;
+        private bool disposed;
+
+        /// <summary>Creates the source with nothing loaded.</summary>
+        /// <param name="logger">Optional logger.</param>
+        public FileSharedSource(ILogger<FileSharedSource>? logger = null)
+        {
+            this.logger = logger ?? NullLogger<FileSharedSource>.Instance;
+            data = new();
+        }
+
         /// <inheritdoc />
-#pragma warning disable CS0067 // Events are never used - raised by agent B3
         public event Action<Shared>? DataUpdated;
 
         /// <inheritdoc />
@@ -31,48 +61,119 @@ namespace R3E.Core.Replay
 
         /// <inheritdoc />
         public event Action<int>? StartLightsChanged;
-#pragma warning restore CS0067
 
         /// <inheritdoc />
-        public Shared Data { get; } = new();
+        public Shared Data => data;
 
         /// <summary>Path of the loaded recording, or <see langword="null"/> when nothing is loaded.</summary>
-        public string? CurrentFile { get; }
+        public string? CurrentFile { get; private set; }
 
         /// <summary>The underlying reader, or <see langword="null"/> when nothing is loaded.</summary>
-        public TelemetryRecordingReader? Reader { get; }
+        public TelemetryRecordingReader? Reader => reader;
 
         /// <summary>Elapsed position of the most recently emitted record.</summary>
-        public TimeSpan Position { get; }
+        public TimeSpan Position => position;
 
         /// <summary>Total duration of the loaded recording.</summary>
-        public TimeSpan Duration { get; }
+        public TimeSpan Duration => reader?.Duration ?? TimeSpan.Zero;
 
         /// <summary><see langword="true"/> once every record has been emitted.</summary>
-        public bool IsAtEnd { get; }
+        public bool IsAtEnd => reader is null || (exhausted && !hasPending);
 
         /// <summary>
         /// Opens a recording, replacing anything already loaded.
         /// </summary>
         /// <param name="path">Path to a <c>.yhtl</c> file.</param>
         /// <exception cref="InvalidDataException">The file was written against a different layout.</exception>
-        /// <remarks>Implemented by agent B3.</remarks>
         public void Load(string path)
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+            Unload();
+
+            reader = new TelemetryRecordingReader(path);
+            CurrentFile = path;
+            data = new();
+            position = TimeSpan.Zero;
+            hasPending = false;
+            exhausted = false;
+
+            if (logger.IsEnabled(LogLevel.Information))
+            {
+                logger.LogInformation(
+                    "Loaded recording '{Path}' ({Duration}, {Frames} frames{Rebuilt})",
+                    path, reader.Duration, reader.TotalFrames,
+                    reader.IndexWasRebuilt ? ", index rebuilt" : string.Empty);
+            }
+        }
 
         /// <summary>Closes the loaded recording and releases the reader.</summary>
-        /// <remarks>Implemented by agent B3.</remarks>
         public void Unload()
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            if (reader is null)
+            {
+                return;
+            }
+
+            try
+            {
+                reader.Dispose();
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "Error disposing recording reader for '{Path}'", CurrentFile);
+            }
+
+            reader = null;
+            CurrentFile = null;
+            data = new();
+            position = TimeSpan.Zero;
+            hasPending = false;
+            exhausted = false;
+        }
 
         /// <summary>
         /// Emits the next record — marshalling and raising the matching event. This is the pump step
         /// the controller calls; it never sleeps.
         /// </summary>
         /// <returns><see langword="false"/> at end of file.</returns>
-        /// <remarks>Implemented by agent B3.</remarks>
         public bool EmitNext()
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            if (!EnsurePending())
+            {
+                return false;
+            }
+
+            var record = pending;
+            hasPending = false;
+            pending = default;
+
+            position = TimeSpan.FromMilliseconds(record.ElapsedMs);
+
+            switch (record.Type)
+            {
+                case RecordingRecordType.Frame:
+                    EmitFrame(record.Frame);
+                    break;
+
+                case RecordingRecordType.StartLights:
+                    StartLightsChanged?.Invoke(record.StartLights);
+                    break;
+
+                default:
+                    // Unknown record types are skipped rather than fatal, so a newer recording still
+                    // replays the parts this build understands.
+                    if (logger.IsEnabled(LogLevel.Debug))
+                    {
+                        logger.LogDebug("Skipping unknown record type {Type}", record.Type);
+                    }
+
+                    break;
+            }
+
+            return true;
+        }
 
         /// <summary>
         /// Returns the elapsed position of the next record without emitting it, so the pump can
@@ -80,22 +181,119 @@ namespace R3E.Core.Replay
         /// </summary>
         /// <param name="position">Receives the position of the next record.</param>
         /// <returns><see langword="false"/> at end of file.</returns>
-        /// <remarks>Implemented by agent B3.</remarks>
         public bool TryPeekNext(out TimeSpan position)
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            if (!EnsurePending())
+            {
+                position = default;
+                return false;
+            }
+
+            position = TimeSpan.FromMilliseconds(pending.ElapsedMs);
+            return true;
+        }
 
         /// <summary>
         /// Repositions the reader without emitting anything. Used by the controller's backward-seek
         /// path, which rewinds to the start and then catches up forward.
         /// </summary>
         /// <param name="position">Target position, clamped to <c>[0, <see cref="Duration"/>]</c>.</param>
-        /// <remarks>Implemented by agent B3.</remarks>
+        /// <remarks>
+        /// The controller only ever calls this with <see cref="TimeSpan.Zero"/>. Repositioning
+        /// anywhere else would put a forward jump into the stream that consumers above
+        /// <see cref="ISharedSource"/> are deliberately not built to survive.
+        /// </remarks>
         public void SeekTo(TimeSpan position)
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            if (reader is null)
+            {
+                return;
+            }
+
+            var clamped = position;
+            if (clamped < TimeSpan.Zero)
+            {
+                clamped = TimeSpan.Zero;
+            }
+            else if (clamped > Duration)
+            {
+                clamped = Duration;
+            }
+
+            hasPending = false;
+            pending = default;
+            exhausted = false;
+
+            if (clamped == TimeSpan.Zero)
+            {
+                reader.Rewind();
+            }
+            else
+            {
+                reader.SeekTo(clamped);
+            }
+
+            this.position = clamped;
+        }
 
         /// <inheritdoc />
-        /// <remarks>Implemented by agent B3.</remarks>
         public void Dispose()
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            Unload();
+            DataUpdated = null;
+            RawFrameReceived = null;
+            StartLightsChanged = null;
+        }
+
+        private void EmitFrame(byte[]? frame)
+        {
+            if (frame is null)
+            {
+                return;
+            }
+
+            // Raw first, mirroring the live sources, so a throwing downstream handler cannot cost a
+            // raw subscriber the frame.
+            RawFrameReceived?.Invoke(frame);
+
+            if (SharedMarshaller.TryMarshalShared(frame, out var marshalled))
+            {
+                data = marshalled;
+                DataUpdated?.Invoke(data);
+            }
+            else
+            {
+                logger.LogWarning("Failed to marshal a replayed frame at {Position}", position);
+            }
+        }
+
+        private bool EnsurePending()
+        {
+            if (hasPending)
+            {
+                return true;
+            }
+
+            if (reader is null || exhausted)
+            {
+                return false;
+            }
+
+            if (!reader.ReadNext(out var record))
+            {
+                exhausted = true;
+                return false;
+            }
+
+            pending = record;
+            hasPending = true;
+            return true;
+        }
     }
 }

--- a/R3E/Core/Replay/ReplayController.cs
+++ b/R3E/Core/Replay/ReplayController.cs
@@ -457,9 +457,24 @@ namespace R3E.Core.Replay
                     }
 
                     Interlocked.Increment(ref frames);
-                    Interlocked.Exchange(ref positionTicks, source.Position.Ticks);
-                    UpdateCatchUpProgress(source.Position);
+                    var landed = source.Position;
+                    Interlocked.Exchange(ref positionTicks, landed.Ticks);
+                    UpdateCatchUpProgress(landed);
                     MaybeNotify(ref lastNotify);
+
+                    // Frame timestamps are discrete and rarely coincide exactly with an arbitrary
+                    // seek target, so the frame that finally reaches it typically overshoots by a
+                    // few milliseconds. Snap the target onto wherever we actually landed in this same
+                    // step - deferring the snap to case 3 on the next iteration would leave a window
+                    // where the top-of-loop check reads target < position and mistakes our own
+                    // overshoot for a brand new backward seek, rewinding to file start and repeating
+                    // this forever (the target is unchanged, so it overshoots the same way every
+                    // time).
+                    if (landed.Ticks >= target.Ticks)
+                    {
+                        Interlocked.CompareExchange(ref targetTicks, landed.Ticks, target.Ticks);
+                    }
+
                     continue;
                 }
 

--- a/R3E/Core/Replay/ReplayController.cs
+++ b/R3E/Core/Replay/ReplayController.cs
@@ -1,0 +1,148 @@
+using R3E.Core.Recording;
+
+namespace R3E.Core.Replay
+{
+    /// <summary>
+    /// Drives replay playback: transport controls, seeking, and catch-up progress for the UI.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Structured as a <em>target-seeking pump</em>, not a queue of seek commands. A single replay
+    /// thread owns playback and continuously moves <see cref="Position"/> toward
+    /// <see cref="TargetPosition"/>, which the UI writes. Seeking is therefore just an assignment, and
+    /// a new target automatically supersedes an in-flight catch-up — drags coalesce for free, with no
+    /// cancellation bookkeeping or stale-seek queue.
+    /// </para>
+    /// <para>
+    /// Seeking is asymmetric: a target ahead of the position consumes frames forward with no reset,
+    /// because state at the current position is already correct; a target behind resets and consumes
+    /// from file start. Either way YaHud only ever sees a monotonically forward frame stream, so no
+    /// feature service needs rewind awareness. Because recording splits per session, file start is
+    /// session start, which makes the backward case trivial.
+    /// </para>
+    /// <para>
+    /// Pacing uses a dedicated thread with a <see cref="System.Diagnostics.Stopwatch"/>, sleeping to
+    /// <c>target − 2 ms</c> and then spinning; <c>Task.Delay</c> resolution is too coarse for 60 Hz.
+    /// </para>
+    /// <para>Implemented by agent B3.</para>
+    /// </remarks>
+    public sealed class ReplayController : IDisposable
+    {
+        /// <summary>
+        /// Catch-ups estimated longer than this suppress widget rendering, so a long rewind does not
+        /// flood the Blazor dispatcher. Shorter scrubs keep rendering, which reads as fast-forward.
+        /// </summary>
+        public static readonly TimeSpan RenderSuppressionThreshold = TimeSpan.FromSeconds(2);
+
+        /// <summary>
+        /// Creates the controller.
+        /// </summary>
+        /// <param name="sourceSwitch">The switch used to activate replay and return to live.</param>
+        /// <param name="logger">Optional logger.</param>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public ReplayController(SharedSourceSwitch sourceSwitch, ILogger<ReplayController>? logger = null)
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <summary>
+        /// Raised whenever transport state, position or catch-up progress changes, so the UI can
+        /// re-render.
+        /// </summary>
+#pragma warning disable CS0067 // Event is never used - raised by agent B3
+        public event Action? StateChanged;
+#pragma warning restore CS0067
+
+        /// <summary><see langword="true"/> when a recording is loaded and replay is active.</summary>
+        public bool IsLoaded { get; }
+
+        /// <summary><see langword="true"/> while the transport is running.</summary>
+        public bool IsPlaying { get; }
+
+        /// <summary>Path of the loaded recording, or <see langword="null"/>.</summary>
+        public string? CurrentFile { get; }
+
+        /// <summary>Header of the loaded recording, or <see langword="null"/>.</summary>
+        public TelemetryRecordingHeader? Header { get; }
+
+        /// <summary>Playback rate multiplier, clamped to <c>[0.1, 8]</c>.</summary>
+        public double Speed { get; set; } = 1d;
+
+        /// <summary>Current playback position.</summary>
+        public TimeSpan Position { get; }
+
+        /// <summary>Position the pump is moving toward, clamped to <c>[0, <see cref="Duration"/>]</c>.</summary>
+        public TimeSpan TargetPosition { get; }
+
+        /// <summary>Total duration of the loaded recording.</summary>
+        public TimeSpan Duration { get; }
+
+        /// <summary>Frames emitted since the recording was loaded or last reset.</summary>
+        public long FrameIndex { get; }
+
+        /// <summary><see langword="true"/> while the pump is consuming frames faster than real time to reach a target.</summary>
+        public bool IsCatchingUp { get; }
+
+        /// <summary>Progress of the running catch-up, <c>0</c>–<c>1</c>.</summary>
+        public double CatchUpProgress { get; }
+
+        /// <summary>
+        /// <see langword="true"/> while widgets should skip rendering, set during a catch-up
+        /// estimated longer than <see cref="RenderSuppressionThreshold"/>.
+        /// </summary>
+        public bool SuppressRendering { get; }
+
+        /// <summary>Lap-start markers of the loaded recording, for the jump-to-lap control.</summary>
+        public IReadOnlyList<RecordingMarker> LapMarkers { get; } = [];
+
+        /// <summary>
+        /// Loads a recording and activates replay mode, positioned at the start and paused.
+        /// </summary>
+        /// <param name="path">Path to a <c>.yhtl</c> file.</param>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void Load(string path)
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <summary>Unloads the recording and returns the switch to the live source.</summary>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void Unload()
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <summary>Starts or resumes playback.</summary>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void Play()
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <summary>Pauses playback, holding the last frame.</summary>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void Pause()
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <summary>
+        /// Sets the pump target. Supersedes any in-flight catch-up; play/pause state is preserved.
+        /// </summary>
+        /// <param name="position">Target position, clamped to <c>[0, <see cref="Duration"/>]</c>.</param>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void Seek(TimeSpan position)
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <summary>
+        /// Advances a fixed number of frames while paused.
+        /// </summary>
+        /// <param name="frames">Frames to advance; must be positive.</param>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void Step(int frames = 1)
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <summary>
+        /// Seeks to the start of a lap, using the recording's <c>LapStart</c> markers.
+        /// </summary>
+        /// <param name="lap">Completed-lap count to jump to.</param>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void JumpToLap(int lap)
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <inheritdoc />
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void Dispose()
+            => throw new NotImplementedException("Implemented by agent B3");
+    }
+}

--- a/R3E/Core/Replay/ReplayController.cs
+++ b/R3E/Core/Replay/ReplayController.cs
@@ -1,4 +1,6 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using R3E.Core.Recording;
+using System.Diagnostics;
 
 namespace R3E.Core.Replay
 {
@@ -24,7 +26,13 @@ namespace R3E.Core.Replay
     /// Pacing uses a dedicated thread with a <see cref="System.Diagnostics.Stopwatch"/>, sleeping to
     /// <c>target − 2 ms</c> and then spinning; <c>Task.Delay</c> resolution is too coarse for 60 Hz.
     /// </para>
-    /// <para>Implemented by agent B3.</para>
+    /// <para>
+    /// Threading: the UI thread only ever writes interlocked scalars and signals
+    /// <see cref="wake"/> — it never blocks on the pump, and the pump never takes a lock the UI
+    /// holds. Only <see cref="Load"/>, <see cref="Unload"/> and <see cref="Dispose"/> synchronise,
+    /// and they do so by stopping the pump thread outright, which keeps the loop itself provably
+    /// single-threaded.
+    /// </para>
     /// </remarks>
     public sealed class ReplayController : IDisposable
     {
@@ -34,115 +42,698 @@ namespace R3E.Core.Replay
         /// </summary>
         public static readonly TimeSpan RenderSuppressionThreshold = TimeSpan.FromSeconds(2);
 
+        /// <summary>Lowest accepted <see cref="Speed"/>.</summary>
+        public const double MinSpeed = 0.1d;
+
+        /// <summary>Highest accepted <see cref="Speed"/>.</summary>
+        public const double MaxSpeed = 8d;
+
+        /// <summary>Longest single wait the pump takes, so control changes are picked up promptly.</summary>
+        private static readonly TimeSpan IdleWait = TimeSpan.FromMilliseconds(50);
+
+        /// <summary>Tail of a frame wait that is spun rather than slept; OS timers are too coarse.</summary>
+        private static readonly TimeSpan SpinThreshold = TimeSpan.FromMilliseconds(2);
+
+        /// <summary>Throttle for progress-only <see cref="StateChanged"/> notifications.</summary>
+        private static readonly TimeSpan ProgressNotifyInterval = TimeSpan.FromMilliseconds(100);
+
+        /// <summary>
+        /// Seed for the recorded-seconds-per-wall-second catch-up rate, refined by measurement after
+        /// the first catch-up. ~100 µs/frame at 60 Hz recorded gives roughly this.
+        /// </summary>
+        private const double DefaultCatchUpRatio = 150d;
+
+        private readonly SharedSourceSwitch sourceSwitch;
+        private readonly ILogger<ReplayController> logger;
+
+        /// <summary>Serialises load/unload/dispose. The pump thread never acquires it.</summary>
+        private readonly object controlGate = new();
+
+        /// <summary>Signalled by every control change so the pump abandons whatever it is waiting on.</summary>
+        private readonly ManualResetEventSlim wake = new(false);
+
+        private readonly Stopwatch clock = Stopwatch.StartNew();
+
+        private Thread? pump;
+        private CancellationTokenSource? pumpCts;
+
+        private long targetTicks;
+        private long positionTicks;
+        private long durationTicks;
+        private long frames;
+        private long speedBits = BitConverter.DoubleToInt64Bits(1d);
+        private long catchUpProgressBits;
+
+        /// <summary>
+        /// Bumped by every control change. The pump uses it to re-anchor its playback clock and to
+        /// abandon an in-flight frame wait, which is what makes a new target supersede an old one.
+        /// </summary>
+        private long controlGeneration;
+
+        private int steps;
+
+        private volatile bool loaded;
+        private volatile bool playing;
+        private volatile bool catchingUp;
+        private volatile bool suppressing;
+        private volatile IReadOnlyList<RecordingMarker> lapMarkers = [];
+
+        private bool disposed;
+
+        // Pump-thread-only state.
+        private double catchUpRatio = DefaultCatchUpRatio;
+        private TimeSpan catchUpFrom;
+        private TimeSpan catchUpTo;
+        private TimeSpan catchUpStartedAt;
+
         /// <summary>
         /// Creates the controller.
         /// </summary>
         /// <param name="sourceSwitch">The switch used to activate replay and return to live.</param>
         /// <param name="logger">Optional logger.</param>
-        /// <remarks>Implemented by agent B3.</remarks>
         public ReplayController(SharedSourceSwitch sourceSwitch, ILogger<ReplayController>? logger = null)
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            ArgumentNullException.ThrowIfNull(sourceSwitch);
+
+            this.sourceSwitch = sourceSwitch;
+            this.logger = logger ?? NullLogger<ReplayController>.Instance;
+        }
 
         /// <summary>
         /// Raised whenever transport state, position or catch-up progress changes, so the UI can
         /// re-render.
         /// </summary>
-#pragma warning disable CS0067 // Event is never used - raised by agent B3
         public event Action? StateChanged;
-#pragma warning restore CS0067
 
         /// <summary><see langword="true"/> when a recording is loaded and replay is active.</summary>
-        public bool IsLoaded { get; }
+        public bool IsLoaded => loaded;
 
         /// <summary><see langword="true"/> while the transport is running.</summary>
-        public bool IsPlaying { get; }
+        public bool IsPlaying => playing;
 
         /// <summary>Path of the loaded recording, or <see langword="null"/>.</summary>
-        public string? CurrentFile { get; }
+        public string? CurrentFile => sourceSwitch.Replay.CurrentFile;
 
         /// <summary>Header of the loaded recording, or <see langword="null"/>.</summary>
-        public TelemetryRecordingHeader? Header { get; }
+        public TelemetryRecordingHeader? Header => sourceSwitch.Replay.Reader?.Header;
 
         /// <summary>Playback rate multiplier, clamped to <c>[0.1, 8]</c>.</summary>
-        public double Speed { get; set; } = 1d;
+        public double Speed
+        {
+            get => BitConverter.Int64BitsToDouble(Interlocked.Read(ref speedBits));
+            set
+            {
+                var clamped = double.IsNaN(value) ? 1d : Math.Clamp(value, MinSpeed, MaxSpeed);
+                Interlocked.Exchange(ref speedBits, BitConverter.DoubleToInt64Bits(clamped));
+                SignalControlChange();
+                RaiseStateChanged();
+            }
+        }
 
         /// <summary>Current playback position.</summary>
-        public TimeSpan Position { get; }
+        public TimeSpan Position => new(Interlocked.Read(ref positionTicks));
 
         /// <summary>Position the pump is moving toward, clamped to <c>[0, <see cref="Duration"/>]</c>.</summary>
-        public TimeSpan TargetPosition { get; }
+        public TimeSpan TargetPosition => new(Interlocked.Read(ref targetTicks));
 
         /// <summary>Total duration of the loaded recording.</summary>
-        public TimeSpan Duration { get; }
+        public TimeSpan Duration => new(Interlocked.Read(ref durationTicks));
 
         /// <summary>Frames emitted since the recording was loaded or last reset.</summary>
-        public long FrameIndex { get; }
+        public long FrameIndex => Interlocked.Read(ref frames);
 
         /// <summary><see langword="true"/> while the pump is consuming frames faster than real time to reach a target.</summary>
-        public bool IsCatchingUp { get; }
+        public bool IsCatchingUp => catchingUp;
 
         /// <summary>Progress of the running catch-up, <c>0</c>–<c>1</c>.</summary>
-        public double CatchUpProgress { get; }
+        public double CatchUpProgress => BitConverter.Int64BitsToDouble(Interlocked.Read(ref catchUpProgressBits));
 
         /// <summary>
         /// <see langword="true"/> while widgets should skip rendering, set during a catch-up
         /// estimated longer than <see cref="RenderSuppressionThreshold"/>.
         /// </summary>
-        public bool SuppressRendering { get; }
+        public bool SuppressRendering => suppressing;
 
         /// <summary>Lap-start markers of the loaded recording, for the jump-to-lap control.</summary>
-        public IReadOnlyList<RecordingMarker> LapMarkers { get; } = [];
+        public IReadOnlyList<RecordingMarker> LapMarkers => lapMarkers;
 
         /// <summary>
         /// Loads a recording and activates replay mode, positioned at the start and paused.
         /// </summary>
         /// <param name="path">Path to a <c>.yhtl</c> file.</param>
-        /// <remarks>Implemented by agent B3.</remarks>
         public void Load(string path)
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+            lock (controlGate)
+            {
+                StopPump();
+                ResetTransportState();
+                lapMarkers = [];
+
+                // Stay unloaded until the file is open: a bad recording must leave the controller
+                // inert rather than half-loaded.
+                loaded = false;
+                sourceSwitch.ActivateReplay(path);
+
+                var reader = sourceSwitch.Replay.Reader;
+                Interlocked.Exchange(ref durationTicks, reader?.Duration.Ticks ?? 0L);
+                lapMarkers = reader is null
+                    ? []
+                    : [.. reader.Markers.Where(m => m.Type == RecordingMarkerType.LapStart)];
+
+                loaded = true;
+                StartPump();
+            }
+
+            logger.LogInformation("Replay loaded '{Path}' ({Duration})", path, Duration);
+            RaiseStateChanged();
+        }
 
         /// <summary>Unloads the recording and returns the switch to the live source.</summary>
-        /// <remarks>Implemented by agent B3.</remarks>
         public void Unload()
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            lock (controlGate)
+            {
+                StopPump();
+
+                // Clear the suppression flag before anything else can observe it: a replay stopped
+                // mid-catch-up must never leave widgets permanently refusing to render.
+                ResetTransportState();
+                lapMarkers = [];
+                loaded = false;
+
+                sourceSwitch.ActivateLive();
+            }
+
+            logger.LogInformation("Replay unloaded; live source restored");
+            RaiseStateChanged();
+        }
 
         /// <summary>Starts or resumes playback.</summary>
-        /// <remarks>Implemented by agent B3.</remarks>
         public void Play()
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            if (!loaded)
+            {
+                return;
+            }
+
+            playing = true;
+            SignalControlChange();
+            RaiseStateChanged();
+        }
 
         /// <summary>Pauses playback, holding the last frame.</summary>
-        /// <remarks>Implemented by agent B3.</remarks>
         public void Pause()
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            playing = false;
+            SignalControlChange();
+            RaiseStateChanged();
+        }
 
         /// <summary>
         /// Sets the pump target. Supersedes any in-flight catch-up; play/pause state is preserved.
         /// </summary>
         /// <param name="position">Target position, clamped to <c>[0, <see cref="Duration"/>]</c>.</param>
-        /// <remarks>Implemented by agent B3.</remarks>
         public void Seek(TimeSpan position)
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            if (!loaded)
+            {
+                return;
+            }
+
+            var duration = Duration;
+            var clamped = position < TimeSpan.Zero
+                ? TimeSpan.Zero
+                : position > duration ? duration : position;
+
+            Interlocked.Exchange(ref targetTicks, clamped.Ticks);
+            SignalControlChange();
+            RaiseStateChanged();
+        }
 
         /// <summary>
         /// Advances a fixed number of frames while paused.
         /// </summary>
         /// <param name="frames">Frames to advance; must be positive.</param>
-        /// <remarks>Implemented by agent B3.</remarks>
         public void Step(int frames = 1)
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            ArgumentOutOfRangeException.ThrowIfNegativeOrZero(frames);
+
+            if (!loaded)
+            {
+                return;
+            }
+
+            Interlocked.Add(ref steps, frames);
+            SignalControlChange();
+        }
 
         /// <summary>
         /// Seeks to the start of a lap, using the recording's <c>LapStart</c> markers.
         /// </summary>
         /// <param name="lap">Completed-lap count to jump to.</param>
-        /// <remarks>Implemented by agent B3.</remarks>
         public void JumpToLap(int lap)
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            var reader = sourceSwitch.Replay.Reader;
+            if (reader is null)
+            {
+                return;
+            }
+
+            if (reader.TryGetLapStart(lap, out var position))
+            {
+                Seek(position);
+            }
+            else if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("No lap-start marker for lap {Lap}", lap);
+            }
+        }
 
         /// <inheritdoc />
-        /// <remarks>Implemented by agent B3.</remarks>
         public void Dispose()
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            lock (controlGate)
+            {
+                if (disposed)
+                {
+                    return;
+                }
+
+                disposed = true;
+                StopPump();
+                ResetTransportState();
+                lapMarkers = [];
+                loaded = false;
+            }
+
+            wake.Dispose();
+            StateChanged = null;
+        }
+
+        /// <summary>
+        /// Clears everything a stale recording could leave behind. Deliberately clears
+        /// <see cref="SuppressRendering"/> and <see cref="IsCatchingUp"/> so tearing replay down
+        /// mid-catch-up cannot leave the HUD frozen.
+        /// </summary>
+        private void ResetTransportState()
+        {
+            playing = false;
+            catchingUp = false;
+            suppressing = false;
+            Interlocked.Exchange(ref catchUpProgressBits, BitConverter.DoubleToInt64Bits(0d));
+            Interlocked.Exchange(ref positionTicks, 0L);
+            Interlocked.Exchange(ref targetTicks, 0L);
+            Interlocked.Exchange(ref durationTicks, 0L);
+            Interlocked.Exchange(ref frames, 0L);
+            Interlocked.Exchange(ref steps, 0);
+        }
+
+        private void StartPump()
+        {
+            pumpCts = new CancellationTokenSource();
+            var token = pumpCts.Token;
+
+            pump = new Thread(() => PumpLoop(token))
+            {
+                IsBackground = true,
+                Name = "YaHud replay pump",
+                Priority = ThreadPriority.AboveNormal,
+            };
+
+            pump.Start();
+        }
+
+        private void StopPump()
+        {
+            var thread = pump;
+            var cts = pumpCts;
+
+            pump = null;
+            pumpCts = null;
+
+            if (thread is null)
+            {
+                return;
+            }
+
+            cts?.Cancel();
+            wake.Set();
+
+            // The pump checks cancellation between individual frames, so even a running catch-up
+            // exits within roughly one frame's work.
+            if (!thread.Join(TimeSpan.FromSeconds(5)))
+            {
+                logger.LogWarning("Replay pump did not stop within the timeout");
+            }
+
+            cts?.Dispose();
+            wake.Reset();
+        }
+
+        private void SignalControlChange()
+        {
+            Interlocked.Increment(ref controlGeneration);
+            wake.Set();
+        }
+
+        /// <summary>
+        /// The target-seeking pump. One iteration does one unit of work and then re-reads the
+        /// target, which is what makes a new target supersede an in-flight catch-up without any
+        /// cancellation bookkeeping.
+        /// </summary>
+        private void PumpLoop(CancellationToken token)
+        {
+            var source = sourceSwitch.Replay;
+            var generation = Interlocked.Read(ref controlGeneration);
+            var anchorReal = clock.Elapsed;
+            var anchorPos = TimeSpan.Zero;
+            var needsAnchor = true;
+            var lastNotify = clock.Elapsed;
+
+            while (!token.IsCancellationRequested)
+            {
+                wake.Reset();
+
+                var current = Interlocked.Read(ref controlGeneration);
+                if (current != generation)
+                {
+                    generation = current;
+                    needsAnchor = true;
+                }
+
+                var target = TargetPosition;
+                var position = source.Position;
+
+                // 1. Target behind position: reset and rewind to file start. Files are split per
+                //    session, so file start is session start — there is no marker to look up. The
+                //    reset itself reaches the feature services through the frame stream: the first
+                //    frame after the rewind carries a lower GameSimulationTicks than the last one
+                //    emitted, which is exactly the condition TelemetryService resets on.
+                if (target < position)
+                {
+                    RewindToStart(source);
+                    needsAnchor = true;
+                    continue;
+                }
+
+                // 2. Target ahead of position: consume forward, one frame per iteration, with no
+                //    reset — state at the current position is already correct. Frames are never
+                //    skipped: level-triggered detection tolerates gaps for most state, but skipping
+                //    a lap or sector boundary would lose a transition.
+                if (target > position)
+                {
+                    if (!catchingUp)
+                    {
+                        BeginCatchUp(position, target);
+                    }
+
+                    if (!source.EmitNext())
+                    {
+                        HandleEndOfFile(source);
+                        continue;
+                    }
+
+                    Interlocked.Increment(ref frames);
+                    Interlocked.Exchange(ref positionTicks, source.Position.Ticks);
+                    UpdateCatchUpProgress(source.Position);
+                    MaybeNotify(ref lastNotify);
+                    continue;
+                }
+
+                // 3. Caught up.
+                if (catchingUp)
+                {
+                    EndCatchUp();
+                    needsAnchor = true;
+                }
+
+                // Snap the target onto the frame actually landed on. A target that fell between two
+                // frames would otherwise sit marginally behind the position and be re-read as a
+                // backward seek on the next iteration. The compare-exchange makes the snap lose to a
+                // seek issued concurrently by the UI.
+                Interlocked.CompareExchange(ref targetTicks, position.Ticks, target.Ticks);
+
+                if (!playing)
+                {
+                    if (TryTakeStep())
+                    {
+                        if (!source.EmitNext())
+                        {
+                            HandleEndOfFile(source);
+                            continue;
+                        }
+
+                        Interlocked.Increment(ref frames);
+                        var stepped = source.Position;
+                        Interlocked.Exchange(ref positionTicks, stepped.Ticks);
+                        Interlocked.CompareExchange(ref targetTicks, stepped.Ticks, position.Ticks);
+                        needsAnchor = true;
+                        RaiseStateChanged();
+                        continue;
+                    }
+
+                    wake.Wait(IdleWait);
+                    continue;
+                }
+
+                // 4. Playing at real-time cadence: pace off the recording's own inter-frame deltas.
+                if (!source.TryPeekNext(out var nextPosition))
+                {
+                    HandleEndOfFile(source);
+                    continue;
+                }
+
+                if (needsAnchor)
+                {
+                    anchorReal = clock.Elapsed;
+                    anchorPos = position;
+                    needsAnchor = false;
+                }
+
+                var speed = Speed;
+                var due = anchorReal + TimeSpan.FromTicks((long)((nextPosition - anchorPos).Ticks / speed));
+
+                if (!WaitUntil(due, generation, token))
+                {
+                    continue;
+                }
+
+                if (!source.EmitNext())
+                {
+                    HandleEndOfFile(source);
+                    continue;
+                }
+
+                Interlocked.Increment(ref frames);
+                var emitted = source.Position;
+                Interlocked.Exchange(ref positionTicks, emitted.Ticks);
+                Interlocked.CompareExchange(ref targetTicks, emitted.Ticks, position.Ticks);
+                MaybeNotify(ref lastNotify);
+            }
+        }
+
+        /// <summary>
+        /// Waits until <paramref name="due"/>, sleeping to <see cref="SpinThreshold"/> before it and
+        /// spinning the rest — <c>Task.Delay</c> and thread sleeps are far too coarse for 60 Hz.
+        /// </summary>
+        /// <returns>
+        /// <see langword="false"/> when the wait was abandoned because a control change superseded
+        /// it or the pump is stopping.
+        /// </returns>
+        private bool WaitUntil(TimeSpan due, long generation, CancellationToken token)
+        {
+            while (true)
+            {
+                if (token.IsCancellationRequested || Interlocked.Read(ref controlGeneration) != generation)
+                {
+                    return false;
+                }
+
+                var remaining = due - clock.Elapsed;
+                if (remaining <= TimeSpan.Zero)
+                {
+                    return true;
+                }
+
+                if (remaining > SpinThreshold)
+                {
+                    var slice = remaining - SpinThreshold;
+                    if (slice > IdleWait)
+                    {
+                        slice = IdleWait;
+                    }
+
+                    // Every control change sets the wake handle, so this returns immediately when a
+                    // seek arrives mid-wait.
+                    wake.Wait(Math.Max(1, (int)slice.TotalMilliseconds));
+                    continue;
+                }
+
+                Thread.SpinWait(50);
+            }
+        }
+
+        private void RewindToStart(FileSharedSource source)
+        {
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("Backward seek from {Position}: rewinding to file start", source.Position);
+            }
+
+            // Only ever zero. Repositioning the reader anywhere else would put a forward jump into
+            // the stream, which is precisely what every feature service is built to not have to
+            // survive.
+            source.SeekTo(TimeSpan.Zero);
+
+            Interlocked.Exchange(ref positionTicks, 0L);
+            Interlocked.Exchange(ref frames, 0L);
+
+            // Force the forward branch to establish a fresh catch-up baseline from zero.
+            catchingUp = false;
+        }
+
+        private bool TryTakeStep()
+        {
+            while (true)
+            {
+                var pending = Volatile.Read(ref steps);
+                if (pending <= 0)
+                {
+                    return false;
+                }
+
+                if (Interlocked.CompareExchange(ref steps, pending - 1, pending) == pending)
+                {
+                    return true;
+                }
+            }
+        }
+
+        private void BeginCatchUp(TimeSpan from, TimeSpan to)
+        {
+            catchUpFrom = from;
+            catchUpTo = to;
+            catchUpStartedAt = clock.Elapsed;
+            catchingUp = true;
+            SetCatchUpProgress(0d);
+
+            var span = to - from;
+            var estimated = span > TimeSpan.Zero
+                ? TimeSpan.FromSeconds(span.TotalSeconds / catchUpRatio)
+                : TimeSpan.Zero;
+
+            // Short forward scrubs keep rendering: they read as a fast-forward, which looks better
+            // than a frozen HUD. Only a long catch-up would flood the Blazor dispatcher.
+            suppressing = estimated > RenderSuppressionThreshold;
+
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug(
+                    "Catching up {Span} from {From} (estimated {Estimated}, rendering {State})",
+                    span, from, estimated, suppressing ? "suppressed" : "live");
+            }
+
+            RaiseStateChanged();
+        }
+
+        private void UpdateCatchUpProgress(TimeSpan position)
+        {
+            var span = (catchUpTo - catchUpFrom).TotalSeconds;
+            SetCatchUpProgress(span > 0d
+                ? Math.Clamp((position - catchUpFrom).TotalSeconds / span, 0d, 1d)
+                : 1d);
+
+            // The estimate can be wrong on the first catch-up of a session. Escalate to suppression
+            // once the catch-up has actually outrun the threshold.
+            if (!suppressing && clock.Elapsed - catchUpStartedAt > RenderSuppressionThreshold)
+            {
+                suppressing = true;
+                RaiseStateChanged();
+            }
+        }
+
+        private void EndCatchUp()
+        {
+            var wall = clock.Elapsed - catchUpStartedAt;
+            var span = catchUpTo - catchUpFrom;
+
+            if (span > TimeSpan.Zero && wall > TimeSpan.FromMilliseconds(50))
+            {
+                // Exponential moving average, so the suppression estimate self-corrects to the
+                // machine it is actually running on.
+                var observed = span.TotalSeconds / wall.TotalSeconds;
+                catchUpRatio = (catchUpRatio * 0.7d) + (observed * 0.3d);
+            }
+
+            catchingUp = false;
+            suppressing = false;
+            SetCatchUpProgress(1d);
+
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                logger.LogDebug("Caught up {Span} in {Wall} ({Ratio:F0}x)", span, wall, catchUpRatio);
+            }
+
+            RaiseStateChanged();
+        }
+
+        private void HandleEndOfFile(FileSharedSource source)
+        {
+            var position = source.Position;
+            Interlocked.Exchange(ref positionTicks, position.Ticks);
+
+            // Pull a target that is beyond the last record back onto it, otherwise the pump spins
+            // trying to reach a position the file does not contain. A concurrent *backward* seek is
+            // behind the position and is deliberately left alone.
+            var target = Interlocked.Read(ref targetTicks);
+            if (target > position.Ticks)
+            {
+                Interlocked.CompareExchange(ref targetTicks, position.Ticks, target);
+            }
+
+            if (catchingUp)
+            {
+                EndCatchUp();
+            }
+
+            if (playing)
+            {
+                playing = false;
+                logger.LogInformation("Replay reached the end of '{Path}'", CurrentFile);
+            }
+
+            RaiseStateChanged();
+        }
+
+        private void SetCatchUpProgress(double value)
+            => Interlocked.Exchange(ref catchUpProgressBits, BitConverter.DoubleToInt64Bits(value));
+
+        private void MaybeNotify(ref TimeSpan lastNotify)
+        {
+            var now = clock.Elapsed;
+            if (now - lastNotify < ProgressNotifyInterval)
+            {
+                return;
+            }
+
+            lastNotify = now;
+            RaiseStateChanged();
+        }
+
+        private void RaiseStateChanged()
+        {
+            try
+            {
+                StateChanged?.Invoke();
+            }
+            catch (Exception ex)
+            {
+                // A throwing UI handler must not be able to kill the pump thread.
+                logger.LogWarning(ex, "A replay StateChanged handler threw");
+            }
+        }
     }
 }

--- a/R3E/Core/Replay/SharedSourceSwitch.cs
+++ b/R3E/Core/Replay/SharedSourceSwitch.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging.Abstractions;
 using R3E.Core.Interfaces;
 using R3E.Data;
 
@@ -17,22 +18,54 @@ namespace R3E.Core.Replay
     /// <c>ITelemetryService</c> subscribes to the switch once at construction and never notices a
     /// swap, so mode switching costs no restart. Recording is disabled while replaying.
     /// </para>
-    /// <para>Implemented by agent B3.</para>
+    /// <para>
+    /// Exactly one source is subscribed at any moment. The inactive source's events are detached, so
+    /// a game running in the background cannot leak frames into a replay, and a subscription can
+    /// never survive a swap or be attached twice.
+    /// </para>
     /// </remarks>
     public sealed class SharedSourceSwitch : ISharedSource, IDisposable
     {
+        private readonly ILogger<SharedSourceSwitch> logger;
+
+        /// <summary>Serialises swaps against each other; the forwarding path itself takes no lock.</summary>
+        private readonly object gate = new();
+
+        // Cached delegates so subscribe/unsubscribe are provably symmetric.
+        private readonly Action<Shared> onDataUpdated;
+        private readonly Action<ReadOnlyMemory<byte>> onRawFrameReceived;
+        private readonly Action<int> onStartLightsChanged;
+
+        private ISharedSource active;
+        private Shared data;
+        private bool disposed;
+
         /// <summary>
         /// Creates the switch, starting in live mode.
         /// </summary>
         /// <param name="liveSource">The live source, already registered as a hosted service.</param>
         /// <param name="replaySource">The file-backed source used for replay.</param>
         /// <param name="logger">Optional logger.</param>
-        /// <remarks>Implemented by agent B3.</remarks>
         public SharedSourceSwitch(ISharedSource liveSource, FileSharedSource replaySource, ILogger<SharedSourceSwitch>? logger = null)
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            ArgumentNullException.ThrowIfNull(liveSource);
+            ArgumentNullException.ThrowIfNull(replaySource);
+
+            this.logger = logger ?? NullLogger<SharedSourceSwitch>.Instance;
+
+            Live = liveSource;
+            Replay = replaySource;
+
+            onDataUpdated = ForwardDataUpdated;
+            onRawFrameReceived = ForwardRawFrame;
+            onStartLightsChanged = ForwardStartLights;
+
+            data = new();
+            active = liveSource;
+            Subscribe(liveSource);
+        }
 
         /// <inheritdoc />
-#pragma warning disable CS0067 // Events are never used - raised by agent B3
         public event Action<Shared>? DataUpdated;
 
         /// <inheritdoc />
@@ -42,44 +75,148 @@ namespace R3E.Core.Replay
         public event Action<int>? StartLightsChanged;
 
         /// <summary>Raised after the active source changes, so consumers can react to the mode swap.</summary>
+        /// <remarks>
+        /// Raised after the old source is detached and the new one attached, but before any frame
+        /// from the new source is forwarded. This is the switch's half of the reset path from
+        /// section 6 of the plan: accumulated feature state belongs to the source that just went
+        /// away and must be discarded here.
+        /// </remarks>
         public event Action? ActiveSourceChanged;
-#pragma warning restore CS0067
 
         /// <inheritdoc />
-        public Shared Data { get; } = new();
+        public Shared Data => data;
 
         /// <summary>The source currently being forwarded.</summary>
-        public ISharedSource Active { get; } = null!;
+        public ISharedSource Active => active;
 
         /// <summary>The live source, regardless of which one is active.</summary>
-        public ISharedSource Live { get; } = null!;
+        public ISharedSource Live { get; }
 
         /// <summary>The file-backed replay source, regardless of which one is active.</summary>
-        public FileSharedSource Replay { get; } = null!;
+        public FileSharedSource Replay { get; }
 
         /// <summary><see langword="true"/> while the replay source is active.</summary>
-        public bool IsReplaying { get; }
+        public bool IsReplaying => ReferenceEquals(active, Replay);
 
         /// <summary>
         /// Switches back to the live source. Unloads the replay file and raises the reset path so
         /// accumulated feature state is discarded.
         /// </summary>
-        /// <remarks>Implemented by agent B3.</remarks>
         public void ActivateLive()
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+
+            lock (gate)
+            {
+                if (ReferenceEquals(active, Live))
+                {
+                    return;
+                }
+
+                Unsubscribe(Replay);
+                Replay.Unload();
+
+                data = new();
+                active = Live;
+                Subscribe(Live);
+            }
+
+            logger.LogInformation("Switched to the live telemetry source");
+            ActiveSourceChanged?.Invoke();
+        }
 
         /// <summary>
         /// Loads a recording and switches to the replay source. Raises the reset path so accumulated
         /// feature state is discarded.
         /// </summary>
         /// <param name="path">Path to a <c>.yhtl</c> file.</param>
-        /// <remarks>Implemented by agent B3.</remarks>
         public void ActivateReplay(string path)
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            ObjectDisposedException.ThrowIf(disposed, this);
+            ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+            lock (gate)
+            {
+                var wasReplaying = ReferenceEquals(active, Replay);
+
+                // Detach the live source before loading, so a running game cannot interleave a frame
+                // with the recording while the swap is in progress.
+                if (!wasReplaying)
+                {
+                    Unsubscribe(Live);
+                }
+                else
+                {
+                    // Re-loading a different file: detach while the reader is replaced.
+                    Unsubscribe(Replay);
+                }
+
+                try
+                {
+                    Replay.Load(path);
+                }
+                catch
+                {
+                    // Loading failed — restore the previous wiring rather than leaving nothing
+                    // subscribed, then let the caller see the exception.
+                    active = Live;
+                    Subscribe(Live);
+                    throw;
+                }
+
+                data = new();
+                active = Replay;
+                Subscribe(Replay);
+            }
+
+            logger.LogInformation("Switched to replay of '{Path}'", path);
+            ActiveSourceChanged?.Invoke();
+        }
 
         /// <inheritdoc />
-        /// <remarks>Implemented by agent B3.</remarks>
         public void Dispose()
-            => throw new NotImplementedException("Implemented by agent B3");
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            lock (gate)
+            {
+                disposed = true;
+                Unsubscribe(active);
+            }
+
+            DataUpdated = null;
+            RawFrameReceived = null;
+            StartLightsChanged = null;
+            ActiveSourceChanged = null;
+        }
+
+        private void Subscribe(ISharedSource source)
+        {
+            source.DataUpdated += onDataUpdated;
+            source.RawFrameReceived += onRawFrameReceived;
+            source.StartLightsChanged += onStartLightsChanged;
+        }
+
+        private void Unsubscribe(ISharedSource source)
+        {
+            source.DataUpdated -= onDataUpdated;
+            source.RawFrameReceived -= onRawFrameReceived;
+            source.StartLightsChanged -= onStartLightsChanged;
+        }
+
+        private void ForwardDataUpdated(Shared value)
+        {
+            data = value;
+            DataUpdated?.Invoke(value);
+        }
+
+        private void ForwardRawFrame(ReadOnlyMemory<byte> frame)
+            => RawFrameReceived?.Invoke(frame);
+
+        private void ForwardStartLights(int startLights)
+            => StartLightsChanged?.Invoke(startLights);
     }
 }

--- a/R3E/Core/Replay/SharedSourceSwitch.cs
+++ b/R3E/Core/Replay/SharedSourceSwitch.cs
@@ -1,0 +1,85 @@
+using R3E.Core.Interfaces;
+using R3E.Data;
+
+namespace R3E.Core.Replay
+{
+    /// <summary>
+    /// The composite <see cref="ISharedSource"/> that makes live↔replay switchable at runtime.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Registered as the singleton <see cref="ISharedSource"/>, it holds the live source (shared
+    /// memory or UDP, chosen by the existing OS/<c>--force-udp</c> logic) and a
+    /// <see cref="FileSharedSource"/>, and forwards events from whichever is active.
+    /// </para>
+    /// <para>
+    /// This matters because <see cref="ISharedSource"/> is otherwise bound at DI registration time.
+    /// <c>ITelemetryService</c> subscribes to the switch once at construction and never notices a
+    /// swap, so mode switching costs no restart. Recording is disabled while replaying.
+    /// </para>
+    /// <para>Implemented by agent B3.</para>
+    /// </remarks>
+    public sealed class SharedSourceSwitch : ISharedSource, IDisposable
+    {
+        /// <summary>
+        /// Creates the switch, starting in live mode.
+        /// </summary>
+        /// <param name="liveSource">The live source, already registered as a hosted service.</param>
+        /// <param name="replaySource">The file-backed source used for replay.</param>
+        /// <param name="logger">Optional logger.</param>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public SharedSourceSwitch(ISharedSource liveSource, FileSharedSource replaySource, ILogger<SharedSourceSwitch>? logger = null)
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <inheritdoc />
+#pragma warning disable CS0067 // Events are never used - raised by agent B3
+        public event Action<Shared>? DataUpdated;
+
+        /// <inheritdoc />
+        public event Action<ReadOnlyMemory<byte>>? RawFrameReceived;
+
+        /// <inheritdoc />
+        public event Action<int>? StartLightsChanged;
+
+        /// <summary>Raised after the active source changes, so consumers can react to the mode swap.</summary>
+        public event Action? ActiveSourceChanged;
+#pragma warning restore CS0067
+
+        /// <inheritdoc />
+        public Shared Data { get; } = new();
+
+        /// <summary>The source currently being forwarded.</summary>
+        public ISharedSource Active { get; } = null!;
+
+        /// <summary>The live source, regardless of which one is active.</summary>
+        public ISharedSource Live { get; } = null!;
+
+        /// <summary>The file-backed replay source, regardless of which one is active.</summary>
+        public FileSharedSource Replay { get; } = null!;
+
+        /// <summary><see langword="true"/> while the replay source is active.</summary>
+        public bool IsReplaying { get; }
+
+        /// <summary>
+        /// Switches back to the live source. Unloads the replay file and raises the reset path so
+        /// accumulated feature state is discarded.
+        /// </summary>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void ActivateLive()
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <summary>
+        /// Loads a recording and switches to the replay source. Raises the reset path so accumulated
+        /// feature state is discarded.
+        /// </summary>
+        /// <param name="path">Path to a <c>.yhtl</c> file.</param>
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void ActivateReplay(string path)
+            => throw new NotImplementedException("Implemented by agent B3");
+
+        /// <inheritdoc />
+        /// <remarks>Implemented by agent B3.</remarks>
+        public void Dispose()
+            => throw new NotImplementedException("Implemented by agent B3");
+    }
+}

--- a/R3E/Core/Replay/SharedSourceSwitch.cs
+++ b/R3E/Core/Replay/SharedSourceSwitch.cs
@@ -24,7 +24,7 @@ namespace R3E.Core.Replay
     /// never survive a swap or be attached twice.
     /// </para>
     /// </remarks>
-    public sealed class SharedSourceSwitch : ISharedSource, IDisposable
+    public sealed class SharedSourceSwitch : ISwitchableSharedSource, IDisposable
     {
         private readonly ILogger<SharedSourceSwitch> logger;
 

--- a/R3E/Core/Services/TelemetryService.cs
+++ b/R3E/Core/Services/TelemetryService.cs
@@ -14,6 +14,14 @@ namespace R3E.Core.Services
         public event Action<int>? StartLightsChanged;
         public event Action<TelemetryData>? NewLap;
         public event Action<TelemetryData>? SessionTypeChanged;
+
+        // Declaration only — the reset semantics (raising this instead of overloading
+        // SessionTypeChanged, and clearing the remaining accumulated fields) are implemented by
+        // agent B4.
+#pragma warning disable CS0067 // Event is never used - raised by agent B4
+        public event Action<TelemetryData>? TelemetryReset;
+#pragma warning restore CS0067
+
         public event Action<TelemetryData>? SessionPhaseChanged;
         public event Action<TelemetryData>? CarPositionChanged;
         public event Action<TelemetryData>? TrackChanged;

--- a/R3E/Core/Services/TelemetryService.cs
+++ b/R3E/Core/Services/TelemetryService.cs
@@ -15,12 +15,7 @@ namespace R3E.Core.Services
         public event Action<TelemetryData>? NewLap;
         public event Action<TelemetryData>? SessionTypeChanged;
 
-        // Declaration only — the reset semantics (raising this instead of overloading
-        // SessionTypeChanged, and clearing the remaining accumulated fields) are implemented by
-        // agent B4.
-#pragma warning disable CS0067 // Event is never used - raised by agent B4
         public event Action<TelemetryData>? TelemetryReset;
-#pragma warning restore CS0067
 
         public event Action<TelemetryData>? SessionPhaseChanged;
         public event Action<TelemetryData>? CarPositionChanged;
@@ -58,12 +53,36 @@ namespace R3E.Core.Services
 
             var tick = raw.Player.GameSimulationTicks;
             var sessionType = (Constant.Session)raw.SessionType;
-            if (sessionType != lastSessionType || tick < lastTick)
+            var sessionTypeChanged = sessionType != lastSessionType;
+
+            // Ticks going backwards means the sim restarted, RaceRoom entered its own replay, or a
+            // rewound telemetry stream is being fed in. Everything accumulated downstream is stale,
+            // which is exactly what a session change means too - hence one reset signal for both.
+            if (sessionTypeChanged || tick < lastTick)
             {
                 lastSessionType = sessionType;
                 lastLapNumber = -1;
-                logger.LogInformation("Session changed: {SessionType}", lastSessionType);
-                SessionTypeChanged?.Invoke(Data);
+
+                // This service's own edge-detection state has to go as well, or the events that
+                // re-establish derived data never fire again when the underlying value happens to
+                // be unchanged across the reset - leaving PlayerStartPosition and RollingStart
+                // stuck at whatever the previous session left behind.
+                this.sessionPhase = Constant.SessionPhase.Unavailable;
+                this.trackId = 0;
+                this.carId = 0;
+
+                // Seeded from the current frame rather than zeroed: a reset is not a position
+                // change, so clearing it would fire a spurious CarPositionChanged on this frame.
+                playerPosition = raw.Position;
+
+                logger.LogInformation("Telemetry reset. Session: {SessionType}", lastSessionType);
+                TelemetryReset?.Invoke(Data);
+
+                if (sessionTypeChanged)
+                {
+                    logger.LogInformation("Session changed: {SessionType}", lastSessionType);
+                    SessionTypeChanged?.Invoke(Data);
+                }
             }
             lastTick = tick;
 

--- a/R3E/Core/Services/TelemetryService.cs
+++ b/R3E/Core/Services/TelemetryService.cs
@@ -40,6 +40,21 @@ namespace R3E.Core.Services
 
             sharedSource.DataUpdated += OnRawDataUpdated;
             sharedSource.StartLightsChanged += SharedSource_StartLightsChanged;
+
+            // Swapping between live telemetry and a recording replaces the whole stream, so
+            // everything accumulated downstream is stale. The swap carries no frame with it, so
+            // rather than resetting against the previous source's last frame, invalidate the tick
+            // watermark and let the next real frame take the normal reset path below - it then runs
+            // against genuine data instead of a fabricated one.
+            if (sharedSource is ISwitchableSharedSource switchable)
+            {
+                switchable.ActiveSourceChanged += OnActiveSourceChanged;
+            }
+        }
+
+        private void OnActiveSourceChanged()
+        {
+            lastTick = int.MaxValue;
         }
 
         private void SharedSource_StartLightsChanged(int startLights)
@@ -165,6 +180,10 @@ namespace R3E.Core.Services
             disposed = true;
             sharedSource.DataUpdated -= OnRawDataUpdated;
             sharedSource.StartLightsChanged -= SharedSource_StartLightsChanged;
+            if (sharedSource is ISwitchableSharedSource switchable)
+            {
+                switchable.ActiveSourceChanged -= OnActiveSourceChanged;
+            }
             GC.SuppressFinalize(this);
         }
     }

--- a/R3E/Core/SharedMemory/RemoteSharedMemoryService.cs
+++ b/R3E/Core/SharedMemory/RemoteSharedMemoryService.cs
@@ -23,6 +23,8 @@ namespace R3E.Core.SharedMemory
 
         public event Action<Shared>? DataUpdated;
 
+        public event Action<ReadOnlyMemory<byte>>? RawFrameReceived;
+
         public event Action<int>? StartLightsChanged;
 
         public Shared Data { get; private set; }
@@ -47,6 +49,10 @@ namespace R3E.Core.SharedMemory
                 logger.LogDebug("Received UDP packet of unexpected size {Size} from {Endpoint}", bytes.Length, ep);
                 return;
             }
+
+            // Raise the raw tap before marshalling so a throwing downstream handler cannot lose the
+            // frame for a recorder.
+            RawFrameReceived?.Invoke(bytes.AsMemory());
 
             if (SharedMarshaller.TryMarshalShared(bytes, out var newData))
             {

--- a/R3E/Core/SharedMemory/SharedMemoryService.cs
+++ b/R3E/Core/SharedMemory/SharedMemoryService.cs
@@ -50,6 +50,8 @@ namespace R3E.Core.SharedMemory
 
         public event Action<Shared>? DataUpdated;
 
+        public event Action<ReadOnlyMemory<byte>>? RawFrameReceived;
+
         public event Action<int>? StartLightsChanged;
 
         public Shared Data => data;
@@ -159,6 +161,10 @@ namespace R3E.Core.SharedMemory
                         {
                             noUpdate = 0;
                             lastSimTicks = simTicks;
+
+                            // Raise the raw tap before marshalling so a throwing downstream handler
+                            // cannot lose the frame for a recorder.
+                            RawFrameReceived?.Invoke(readBuffer.AsMemory(0, bytesRead));
 
                             if (SharedMarshaller.TryMarshalShared(readBuffer, out var newData))
                             {

--- a/R3E/Features/Fuel/FuelService.cs
+++ b/R3E/Features/Fuel/FuelService.cs
@@ -38,6 +38,20 @@ namespace R3E.Features.Fuel
             // Subscribe to events
             telemetry.NewLap += OnNewLap;
             telemetry.SessionPhaseChanged += OnSessionPhaseChanged;
+            telemetry.TelemetryReset += OnTelemetryReset;
+        }
+
+        /// <summary>
+        /// Re-seeds the fuel baseline whenever accumulated state becomes invalid (session restart,
+        /// RaceRoom replay, rewound stream). Without this <see cref="oldFuelRemaining"/> survives
+        /// from the previous session and the first lap afterwards reports nonsense consumption -
+        /// frequently negative, once the tank has been refilled.
+        /// </summary>
+        private void OnTelemetryReset(TelemetryData data)
+        {
+            oldFuelRemaining = data.Raw.FuelLeft;
+            Data.LastLapFuelUsage = 0;
+            logger.LogInformation("Fuel tracking reset: {FuelLeft:F2}L", oldFuelRemaining);
         }
 
         private void OnSessionPhaseChanged(TelemetryData data)
@@ -67,6 +81,7 @@ namespace R3E.Features.Fuel
 
             telemetry.NewLap -= OnNewLap;
             telemetry.SessionPhaseChanged -= OnSessionPhaseChanged;
+            telemetry.TelemetryReset -= OnTelemetryReset;
 
             GC.SuppressFinalize(this);
         }

--- a/R3E/Features/Radar/RadarService.cs
+++ b/R3E/Features/Radar/RadarService.cs
@@ -27,16 +27,16 @@ namespace R3E.Features.Radar
             RadarData = new RadarData(telemetryService.Data);
 
             telemetryService.DataUpdated += OnDataUpdated;
-            telemetryService.SessionTypeChanged += OnSessionTypeChanged;
+            telemetryService.TelemetryReset += OnTelemetryReset;
 
             logger.LogInformation("RadarService initialized");
         }
 
-        private void OnSessionTypeChanged(TelemetryData data)
+        private void OnTelemetryReset(TelemetryData data)
         {
             lock (sync)
             {
-                logger.LogInformation("RadarService: session changed - clearing radar state.");
+                logger.LogInformation("RadarService: telemetry reset - clearing radar state.");
                 RadarData.DriverStates = new Dictionary<int, RadarDriverSnapshot>();
                 RadarData.ClosestDistance = null;
 
@@ -156,7 +156,7 @@ namespace R3E.Features.Radar
         public void Dispose()
         {
             telemetryService.DataUpdated -= OnDataUpdated;
-            telemetryService.SessionTypeChanged -= OnSessionTypeChanged;
+            telemetryService.TelemetryReset -= OnTelemetryReset;
             GC.SuppressFinalize(this);
         }
 

--- a/R3E/Features/Sector/SectorService.cs
+++ b/R3E/Features/Sector/SectorService.cs
@@ -27,10 +27,10 @@ namespace R3E.Features.Sector
 
             // Subscribe to core telemetry events
             telemetry.DataUpdated += OnDataUpdated;
-            telemetry.SessionTypeChanged += OnSessionChanged;
+            telemetry.TelemetryReset += OnTelemetryReset;
         }
 
-        private void OnSessionChanged(TelemetryData data)
+        private void OnTelemetryReset(TelemetryData data)
         {
             lastSectorIndex = -1;
         }
@@ -68,7 +68,7 @@ namespace R3E.Features.Sector
         public void Dispose()
         {
             telemetry.DataUpdated -= OnDataUpdated;
-            telemetry.SessionTypeChanged -= OnSessionChanged;
+            telemetry.TelemetryReset -= OnTelemetryReset;
             GC.SuppressFinalize(this);
         }
     }

--- a/R3E/Features/TimeGap/AdvancedTimeGapService.cs
+++ b/R3E/Features/TimeGap/AdvancedTimeGapService.cs
@@ -22,16 +22,16 @@ namespace R3E.Features.TimeGap
             this.telemetryService = telemetryService;
 
             this.telemetryService.DataUpdated += OnDataUpdated;
-            this.telemetryService.SessionTypeChanged += OnSessionTypeChanged;
+            this.telemetryService.TelemetryReset += OnTelemetryReset;
 
             this.logger.LogInformation("TimeGapService initialized");
         }
 
-        private void OnSessionTypeChanged(TelemetryData data)
+        private void OnTelemetryReset(TelemetryData data)
         {
             lock (@lock)
             {
-                logger.LogInformation("New Session. Clearing Car Histories.");
+                logger.LogInformation("Telemetry reset. Clearing Car Histories.");
                 carHistories.Clear();
 
                 if (data.Raw.LayoutLength > 0)
@@ -162,7 +162,7 @@ namespace R3E.Features.TimeGap
         public void Dispose()
         {
             telemetryService.DataUpdated -= OnDataUpdated;
-            telemetryService.SessionTypeChanged -= OnSessionTypeChanged;
+            telemetryService.TelemetryReset -= OnTelemetryReset;
             GC.SuppressFinalize(this);
         }
     }

--- a/R3E/Features/TimeGap/SimpleTimeGapService.cs
+++ b/R3E/Features/TimeGap/SimpleTimeGapService.cs
@@ -23,17 +23,19 @@ namespace R3E.Features.TimeGap
             this.telemetryService = telemetryService;
 
             this.telemetryService.DataUpdated += OnDataUpdated;
-            this.telemetryService.SessionTypeChanged += OnSessionTypeChanged;
+            this.telemetryService.TelemetryReset += OnTelemetryReset;
 
             this.logger.LogInformation("SimpleTimeGapService initialized");
         }
 
-        private void OnSessionTypeChanged(TelemetryData data)
+        private void OnTelemetryReset(TelemetryData data)
         {
+            currentData = null;
+
             if (data.Raw.LayoutLength > 0)
             {
                 trackLength = data.Raw.LayoutLength;
-                logger.LogInformation("Session changed. Track length: {TrackLength:F1}m", trackLength);
+                logger.LogInformation("Telemetry reset. Track length: {TrackLength:F1}m", trackLength);
             }
         }
 
@@ -96,7 +98,7 @@ namespace R3E.Features.TimeGap
         public void Dispose()
         {
             telemetryService.DataUpdated -= OnDataUpdated;
-            telemetryService.SessionTypeChanged -= OnSessionTypeChanged;
+            telemetryService.TelemetryReset -= OnTelemetryReset;
             GC.SuppressFinalize(this);
         }
     }

--- a/R3E/Features/TireWidget/TireWidgetService.cs
+++ b/R3E/Features/TireWidget/TireWidgetService.cs
@@ -42,16 +42,16 @@ namespace R3E.Features.TireWidget
             TireWidgetData = new TireWidgetData(telemetryService.Data);
 
             telemetryService.DataUpdated += OnDataUpdated;
-            telemetryService.SessionTypeChanged += OnSessionTypeChanged;
+            telemetryService.TelemetryReset += OnTelemetryReset;
 
             logger.LogInformation("TireWidgetService initialized");
         }
 
-        private void OnSessionTypeChanged(TelemetryData data)
+        private void OnTelemetryReset(TelemetryData data)
         {
             lock (sync)
             {
-                logger.LogInformation("TireWidgetService: session changed - clearing state.");
+                logger.LogInformation("TireWidgetService: telemetry reset - clearing state.");
                 TireWidgetData.FrontTireAge = 0;
                 TireWidgetData.RearTireAge = 0;
                 TireWidgetData.FrontLeftTireTemp = 0;
@@ -84,7 +84,7 @@ namespace R3E.Features.TireWidget
         public void Dispose()
         {
             telemetryService.DataUpdated -= OnDataUpdated;
-            telemetryService.SessionTypeChanged -= OnSessionTypeChanged;
+            telemetryService.TelemetryReset -= OnTelemetryReset;
             GC.SuppressFinalize(this);
         }
 

--- a/R3E/Utilities/LaunchOptions.cs
+++ b/R3E/Utilities/LaunchOptions.cs
@@ -15,12 +15,19 @@ namespace R3E.Utilities
         /// Creates a port option that only accepts a valid TCP/UDP port number.
         /// </summary>
         public static Option<int> CreatePortOption(string name, string description, int defaultPort)
+            => CreateIntOption(name, description, defaultPort, MinPort, MaxPort, "port");
+
+        /// <summary>
+        /// Creates an integer option that only accepts a value inside
+        /// <paramref name="min"/>..<paramref name="max"/>.
+        /// </summary>
+        public static Option<int> CreateIntOption(string name, string description, int defaultValue, int min, int max, string helpName)
         {
             var option = new Option<int>(name)
             {
                 Description = description,
-                DefaultValueFactory = _ => defaultPort,
-                HelpName = "port",
+                DefaultValueFactory = _ => defaultValue,
+                HelpName = helpName,
             };
 
             option.Validators.Add(result =>
@@ -35,11 +42,11 @@ namespace R3E.Utilities
 
                 if (!int.TryParse(token, out var value))
                 {
-                    result.AddError($"{name} must be a whole number between {MinPort} and {MaxPort}, but was '{token}'.");
+                    result.AddError($"{name} must be a whole number between {min} and {max}, but was '{token}'.");
                 }
-                else if (value is < MinPort or > MaxPort)
+                else if (value < min || value > max)
                 {
-                    result.AddError($"{name} must be between {MinPort} and {MaxPort}, but was {value}.");
+                    result.AddError($"{name} must be between {min} and {max}, but was {value}.");
                 }
             });
 
@@ -74,6 +81,63 @@ namespace R3E.Utilities
             }
 
             port = value;
+            return true;
+        }
+
+        /// <summary>
+        /// Validates an integer that came from configuration rather than the command line, so a typo
+        /// in appsettings.json reports the same friendly error instead of an unhandled conversion
+        /// exception. An absent or empty value falls back to <paramref name="defaultValue"/>.
+        /// </summary>
+        public static bool TryReadInt(string? rawValue, string source, int defaultValue, int min, int max, out int value, out string? error)
+        {
+            error = null;
+            value = defaultValue;
+
+            if (string.IsNullOrWhiteSpace(rawValue))
+            {
+                return true;
+            }
+
+            if (!int.TryParse(rawValue, out var parsed))
+            {
+                error = $"{source} must be a whole number between {min} and {max}, but was '{rawValue}'.";
+                return false;
+            }
+
+            if (parsed < min || parsed > max)
+            {
+                error = $"{source} must be between {min} and {max}, but was {parsed}.";
+                return false;
+            }
+
+            value = parsed;
+            return true;
+        }
+
+        /// <summary>
+        /// Validates a boolean that came from configuration rather than the command line, for the
+        /// same reason as <see cref="TryReadInt"/>: a typo such as <c>"Enabled": "yess"</c> would
+        /// otherwise bind to <see langword="false"/> silently or throw. An absent or empty value
+        /// falls back to <paramref name="defaultValue"/>.
+        /// </summary>
+        public static bool TryReadBool(string? rawValue, string source, bool defaultValue, out bool value, out string? error)
+        {
+            error = null;
+            value = defaultValue;
+
+            if (string.IsNullOrWhiteSpace(rawValue))
+            {
+                return true;
+            }
+
+            if (!bool.TryParse(rawValue, out var parsed))
+            {
+                error = $"{source} must be true or false, but was '{rawValue}'.";
+                return false;
+            }
+
+            value = parsed;
             return true;
         }
     }

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A modern, customizable HUD (Heads-Up Display) overlay for RaceRoom Racing Experi
 - **Cross-Platform Support**: Native Windows support with Linux compatibility via relay service
 - **Customizable Widgets**: Drag-and-drop widget positioning with persistent settings
 - **Real-Time Telemetry**: Live data from RaceRoom's shared memory API
+- **Record & Replay**: Capture telemetry to a file and replay it through the HUD with the game closed
 - **Modern UI**: Clean, responsive interface built with Blazor
 - **Multiple Widgets**: Clock, MoTec-style display, user inputs, and more (with more coming!)
 - **Settings Panel**: Comprehensive configuration interface for all widgets
@@ -71,6 +72,11 @@ Both executables accept launch arguments; run either with `--help` for the full 
 | `--udp-port=<port>` | YaHud, R3ERelay | `10101` | Telemetry UDP port — **must match on both** |
 | `--udp-host=<ip>` | R3ERelay | `127.0.0.1` | IP address the relay sends telemetry to |
 | `--force-udp` | YaHud | off | Receive telemetry over UDP from the relay instead of reading shared memory directly (Windows only — it is already the default elsewhere) |
+| `--record` | YaHud | off | Make telemetry recording available (stays inert until started) |
+| `--record-autostart` | YaHud | off | Begin recording at launch. Implies `--record` |
+| `--recording-dir=<dir>` | YaHud | `<LocalApplicationData>/YaHud/recordings` | Folder recordings are written to |
+| `--recording-block-seconds=<n>` | YaHud | `3` | Compression block duration (1–60) |
+| `--replay=<file>` | YaHud | off | Start in replay mode on a `.yhtl` recording instead of reading live telemetry |
 
 Examples:
 
@@ -84,6 +90,10 @@ R3ERelay.exe --udp-port=10200
 
 # Run the relay on the gaming PC and the HUD on another machine
 R3ERelay.exe --udp-port=10200 --udp-host=192.168.1.50
+
+# Record telemetry to a file, then play it back later without the game running
+YaHud.exe --record-autostart
+YaHud.exe --replay="C:\Users\me\AppData\Local\YaHud\recordings\2026-07-25_19-04-spa\03-race.yhtl"
 ```
 
 YaHud also reads these values from the `appsettings.json` next to its executable,
@@ -93,7 +103,14 @@ argument always wins over the file:
 ```json
 "YaHud": {
   "WebPort": 5000,
-  "Udp": { "Port": 10101, "ForceUdp": false }
+  "Udp": { "Port": 10101, "ForceUdp": false },
+  "Recording": {
+    "Enabled": false,
+    "AutoStart": false,
+    "Directory": null,
+    "BlockSeconds": 3
+  },
+  "Replay": { "File": null }
 }
 ```
 
@@ -162,6 +179,25 @@ above) or the plain binary from `R3E.YaHud-linux-x64-v{version}.zip`:
 The relay service forwards RaceRoom's shared memory data over UDP, allowing the HUD to run natively on Linux.
 
 > **Tip**: You can create a shell script to automate starting the relay service with the correct Proton environment.
+
+#### Recording and replay
+
+YaHud can record raw telemetry to a `.yhtl` file and play it back through the
+full pipeline later, with the game closed. Replay runs inside YaHud itself —
+there is no separate application.
+
+```bash
+# Record: one file per session, in a timestamped run folder
+YaHud.exe --record-autostart
+
+# Replay: drive the HUD from a recording instead of live telemetry
+YaHud.exe --replay="...\2026-07-25_19-04-spa\03-race.yhtl"
+```
+
+Recording is opt-in and off by default. It is the preferred way to reproduce a
+widget bug, and it makes widget development possible without launching RaceRoom.
+See [Telemetry Recording and Replay](docs/telemetry-recording.md) for the file
+format, seek semantics and limitations.
 
 ## 🎯 Usage
 
@@ -274,7 +310,9 @@ YaHud/
 │   ├── Core/
 │   │   ├── Interfaces/     # ITelemetryService, ITelemetryEventBus, ISharedSource
 │   │   ├── Services/       # TelemetryService, TelemetryEventBus, TelemetryData
-│   │   └── SharedMemory/   # SharedMemoryService (Windows), RemoteSharedMemoryService (UDP)
+│   │   ├── SharedMemory/   # SharedMemoryService (Windows), RemoteSharedMemoryService (UDP)
+│   │   ├── Recording/      # .yhtl telemetry recorder, writer, reader, frame truncation
+│   │   └── Replay/         # In-process replay: FileSharedSource, SharedSourceSwitch, ReplayController
 │   ├── Features/           # Feature service + data class pairs (Fuel, Radar, Sector, …)
 │   ├── Converters/         # Unit converters (speed, temperature, pressure, angular)
 │   ├── Networking/         # UDP receiver
@@ -286,7 +324,7 @@ YaHud/
 │   ├── Assets/             # Tray icon
 │   ├── Linux/              # D-Bus StatusNotifierItem tray icon for Linux
 │   └── Windows/            # Windows Forms NotifyIcon tray for Windows
-├── docs/                   # AppImage packaging and Linux D-Bus tray internals
+├── docs/                   # AppImage packaging, Linux D-Bus tray internals, telemetry recording
 ├── packaging/appimage/     # AppRun, desktop entry and icon for the Linux AppImage
 ├── scripts/                # Developer scripts (headless tray D-Bus test)
 ├── git/hooks/              # Pre-push hooks

--- a/docs/telemetry-recording.md
+++ b/docs/telemetry-recording.md
@@ -1,0 +1,380 @@
+# Telemetry Recording and Replay
+
+YaHud can write RaceRoom's raw telemetry to a file and play it back through the
+full pipeline, so the whole HUD behaves exactly as it did live. Three things
+that were previously impossible become routine:
+
+- **Reproducing a situation offline.** A bug seen once during a race can be
+  replayed as often as you like.
+- **Developing widgets without launching RaceRoom.** Anything time-dependent —
+  fuel projection, sector deltas, time gaps, radar, lap transitions — can only
+  be exercised by data that changes over time. Test mode renders static values;
+  a recording does not.
+- **Making bug reports reproducible.** A user can attach a recording.
+
+Replay runs **inside YaHud**. There is no separate replay application and no UDP
+hop — the file-backed source is simply a third `ISharedSource`, so everything
+above that interface is unchanged and unaware it is being replayed.
+
+Recording is **opt-in**: `Enabled` is `false` by default, so nobody writes
+multi-GB files by accident.
+
+## Files
+
+| File | Responsibility |
+|------|----------------|
+| [`FrameTruncation.cs`](../R3E/Core/Recording/FrameTruncation.cs) | Truncates a raw frame to the drivers that exist, and restores it. |
+| [`TelemetryRecordingHeader.cs`](../R3E/Core/Recording/TelemetryRecordingHeader.cs) | The header record, the record/marker enums, and the version guard. |
+| [`TelemetryRecordingWriter.cs`](../R3E/Core/Recording/TelemetryRecordingWriter.cs) | One file: block buffering, Brotli, index and markers, footer patch on close. |
+| [`TelemetryRecordingReader.cs`](../R3E/Core/Recording/TelemetryRecordingReader.cs) | Header validation, index load-or-rebuild, seek, forward record streaming. |
+| [`TelemetryRecorder.cs`](../R3E/Core/Recording/TelemetryRecorder.cs) | Capture: raw-frame tap, bounded channel, background writer, session splitting. |
+| [`RecordingOptions.cs`](../R3E/Core/Recording/RecordingOptions.cs) | The `YaHud:Recording` settings object. |
+| [`FileSharedSource.cs`](../R3E/Core/Replay/FileSharedSource.cs) | An `ISharedSource` backed by a recording instead of by the game. |
+| [`SharedSourceSwitch.cs`](../R3E/Core/Replay/SharedSourceSwitch.cs) | Composite source that swaps live↔replay at runtime. |
+| [`ReplayController.cs`](../R3E/Core/Replay/ReplayController.cs) | Transport controls and the target-seeking playback pump. |
+
+## Recording
+
+### Options
+
+Every option is settable two ways — a launch argument and an `appsettings.json`
+key, one-to-one. A launch argument wins where one was supplied; otherwise the
+file keeps providing the value.
+
+| Launch argument | Config key | Default | Meaning |
+|---|---|---|---|
+| `--record` | `YaHud:Recording:Enabled` | `false` | Makes recording available: registers the recorder and shows the controls. Recording stays inert until started. |
+| `--record-autostart` | `YaHud:Recording:AutoStart` | `false` | Begin recording at launch without pressing the button. Implies `--record`. |
+| `--recording-dir <dir>` | `YaHud:Recording:Directory` | `null` | Output folder. |
+| `--recording-block-seconds <seconds>` | `YaHud:Recording:BlockSeconds` | `3` | Compression block duration, 1–60. |
+| `--replay <file>` | `YaHud:Replay:File` | `null` | Start in replay mode on this recording. |
+
+```json
+"YaHud": {
+  "Recording": {
+    "Enabled": false,
+    "AutoStart": false,
+    "Directory": null,
+    "BlockSeconds": 3
+  },
+  "Replay": { "File": null }
+}
+```
+
+`Enabled` and `AutoStart` are deliberately separate. `Enabled` makes the feature
+*available* but inert, which is what the UI toggle drives; `AutoStart` is for
+scripted or headless capture where there is nobody to press the button.
+
+Bad values fail at startup with the same friendly message from either source —
+a `BlockSeconds` outside 1–60, a `Directory` that cannot be created, a
+`--replay` path that does not exist. That is deliberate: by the time the first
+frame arrives the user is driving, the HUD looks fine, and the only symptom
+would be that no file ever appears.
+
+When `Directory` is unset, recordings land in
+`<LocalApplicationData>/YaHud/recordings`, which resolves on both Windows and
+Linux.
+
+### Run folders and session splitting
+
+One recording *run* produces one file **per session**. The recorder watches
+`SessionType` and `TrackId` straight out of the raw buffer — no marshalling —
+and on a change finalises the current file and opens a new one on the next
+frame. So a Practice → Qualify → Race progression becomes three files in one
+run folder:
+
+```
+recordings/
+  2026-07-25_19-04-spa/
+    01-practice.yhtl
+    02-qualify.yhtl
+    03-race.yhtl
+```
+
+The folder is named from the time you pressed record plus a slug of the track
+name; the file is numbered in run order and named after the `Constant.Session`
+value (`session` when the value is not a known enum member). This split is
+independent of the start/stop control — the toggle governs *whether* recording
+happens, the split governs how it is filed.
+
+The point of the split is that **file start is session start**, which is what
+makes replay seeking simple (see [Seek semantics](#seek-semantics)).
+
+### The write path
+
+`RawFrameReceived` fires synchronously on the telemetry polling thread, so the
+ingest path must never wait on disk — a disk hiccup, AV scan or full buffer
+would otherwise stall telemetry and visibly freeze the HUD.
+
+```
+RawFrameReceived -> truncate into an ArrayPool buffer -> bounded channel (DropWrite)
+                                                             |
+                                        background writer task -> Brotli -> file
+```
+
+The channel holds 240 records, roughly four seconds of headroom at 60 Hz. When
+it fills, frames are **dropped rather than queued**: for a debug recorder,
+dropping beats stuttering the HUD, and every frame is independently decodable so
+a gap only shows as a longer inter-frame delta on replay. `DroppedFrames`
+surfaces the count; non-zero means the disk could not keep up.
+
+The file is created on the **first frame**, not when recording starts. That is
+what lets the header carry track, car and driver metadata — none of which exists
+before a frame has arrived. A session that produces no frames simply produces no
+file, which is the right outcome.
+
+Recording is suppressed while replaying. The recorder is handed the
+`ISharedSource` registration, which resolves to the live/replay switch, so
+without that guard it would happily capture replayed frames back into a
+near-duplicate file.
+
+### How large is a recording?
+
+The honest answer is **not yet measured against real telemetry**. What is
+measured and solid:
+
+- `Marshal.SizeOf<Shared>()` is **43,996 bytes**.
+- `NumCars` followed by `DriverData[128]` are the last fields of `Shared`, so
+  storing only the drivers that exist is a pure byte-range truncation. At a
+  20-car grid that gives **43,996 → ~8,572 bytes, a reliable 5.1× reduction**
+  before compression runs at all.
+
+What is *not* pinned down is Brotli's further contribution, which depends
+entirely on how byte-stable real frames are from one tick to the next.
+Measurements against synthetic profiles could only bracket the result at
+**16–148 MB per 10 minutes** at 20 cars. Treat any figure inside that range as
+unverified until someone captures a real session and reports the number.
+
+## Replay
+
+### Entry points
+
+`--replay <file>` (or `YaHud:Replay:File`) loads a recording at startup and
+switches the HUD into replay mode before the first browser connects; live
+telemetry is not read at all. Otherwise a recording is picked and driven from
+the record/replay controls in the HUD.
+
+Loading a recording puts the transport at position zero, paused.
+
+### Transport
+
+`ReplayController` exposes `Play`, `Pause`, `Seek`, `Step`, `JumpToLap`,
+`Speed`, `Position`, `Duration` and catch-up progress, and raises `StateChanged`
+so the UI can re-render.
+
+- **Speed** is clamped to `[0.1, 8]`.
+- **`JumpToLap`** resolves the position from the file's `LapStart` markers, so
+  it costs no decoding — but the jump itself is an ordinary seek and pays
+  whatever that seek costs.
+- **Step** advances exactly one record while paused.
+- Play/pause state is preserved across a seek, and targets are clamped to
+  `[0, Duration]`.
+
+Playback is paced on a dedicated thread with a `Stopwatch`, sleeping to
+`target − 2 ms` and then spinning; `Task.Delay` resolution (~15 ms on Windows)
+is far too coarse for 60 Hz.
+
+The controller is a **target-seeking pump**, not a queue of seek commands. One
+thread owns playback and continuously moves `Position` toward a `TargetPosition`
+that the UI writes, so seeking is just an assignment and a new target
+automatically supersedes an in-flight catch-up. Rapid scrubbing coalesces for
+free, with no cancellation bookkeeping.
+
+### Seek semantics
+
+This is the part worth understanding before you use replay in anger.
+
+Seeking corrupts every consumer that accumulates state across frames. Rather
+than teach every feature service to rewind, replay guarantees the one property
+that makes rewind awareness unnecessary:
+
+> **YaHud only ever sees a monotonically forward frame stream.**
+
+Seeking from T₀ to T₁ therefore works like this:
+
+| Direction | Action | Cost |
+|---|---|---|
+| **Forward** (T₁ ≥ T₀) | Consume every frame T₀ → T₁. **No reset** — state at T₀ is already correct. | ∝ (T₁ − T₀) |
+| **Backward** (T₁ < T₀) | Reset, rewind to **file start**, consume 0 → T₁. | ∝ T₁ |
+
+There are no forward jumps at all, and backward movement appears downstream only
+as a single reset at file start — delivered through the frame stream itself,
+because the first frame after the rewind carries a lower `GameSimulationTicks`
+than the last one emitted, which is exactly the condition `TelemetryService`
+resets on. Because recording splits per session, file start *is* session start,
+so the backward case needs no marker lookup: the reader is only ever
+repositioned to zero.
+
+Two consequences follow, and they are the trade this design makes deliberately:
+
+- **State after a seek is exact, in both directions.** A warm-up window could
+  never rebuild stint fuel totals or tire age since a pitstop several laps back;
+  consuming every intervening frame does. Frames are never skipped to go faster —
+  level-triggered detection tolerates gaps for most state, but skipping across a
+  lap or sector boundary would lose a transition, and exactness is the point.
+- **Backward seeks cost time proportional to distance from the start, not from
+  where you were.** Nudging the slider back five seconds late in a session costs
+  the same as rewinding to the beginning. Rewinding to early in a session is
+  cheap regardless of how far in you had played. Forward seeks are cheap.
+
+During a catch-up estimated to take longer than **2 seconds**, the controller
+sets a suppression flag that widgets honour, so they skip rendering and draw
+once at the destination instead of flooding the Blazor dispatcher. Shorter
+scrubs keep rendering, which reads as a fast-forward. The estimate is a
+self-correcting moving average of observed catch-up rate, and it escalates to
+suppression if a catch-up outruns the threshold in practice. Tearing replay down
+mid-catch-up clears the flag, so the HUD can never be left permanently refusing
+to render.
+
+## The `.yhtl` format
+
+Extension `.yhtl`, little-endian throughout, written with `BinaryWriter`. Strings
+are `BinaryWriter`-style length-prefixed UTF-8 — a 7-bit-encoded length followed
+by the bytes — decoded out of the struct's fixed `byte[64]` fields at the null
+terminator.
+
+```
+[Header]  "YHTL" | formatVer u16 | flags u16 | sizeofShared i32
+          | allDriversOffset i32 | driverDataSize i32
+          | r3eVersionMajor i32 | r3eVersionMinor i32
+          | yaHudVersion str | startUtcTicks i64
+          | indexOffset i64          <- patched on clean close, 0 if the app crashed
+          |
+          | -- metadata, captured from the first frame --
+          | sessionType i32 | sessionPhaseAtStart i32
+          | trackId i32 | layoutId i32 | trackName str | layoutName str
+          | playerName str | playerCarModelId i32 | playerCarName str
+          | playerClassId i32 | playerClassPerfIndex i32
+          | numCarsAtStart i32
+
+[Block]*  compressedLen i32 | firstFrameMs u32 | frameCount i32
+          | Brotli{ ( elapsedMs u32 | recordType u8 | payloadLen i32 | payload )* }
+                      recordType: 0 = Frame (truncated Shared bytes)
+                                  1 = StartLights (i32)
+
+[Footer]  entryCount i32 | ( firstFrameMs u32 | fileOffset i64 | frameCount i32 )*
+          | markerCount i32 | ( elapsedMs u32 | markerType u8 | value i32 )*
+          | -- final summary --
+          | totalFrames i64 | durationMs u32 | maxNumCars i32
+          | classCount i32 | ( classId i32 )*
+          | "YHTX"
+```
+
+The current `formatVer` is `1`. `flags` is reserved and currently written as
+zero.
+
+### The header is not fixed-size
+
+Five of its fields are length-prefixed strings (`yaHudVersion`, `trackName`,
+`layoutName`, `playerName`, `playerCarName`), so the header's byte length varies
+per file — and `indexOffset` cannot sit at a constant offset, which is why the
+writer remembers where it wrote that slot in order to patch it on close.
+
+The property that actually matters is a different one: **the header is complete
+after the first frame.** Everything in it is knowable from a single frame, which
+is what lets the recordings browser show track, layout, session type, car, class
+and driver count for a whole folder without opening or decoding anything.
+
+### Frame truncation
+
+`NumCars` then `DriverData[128]` are the last fields of `Shared`, so the
+variable-size part is the tail:
+
+- **Truncate**: `length = offsetOf(NumCars) + 4 + numCars * sizeof(DriverData)`.
+  No copy, no re-encoding. `numCars` is clamped to `[0, 128]` so a garbage frame
+  cannot produce a wild length.
+- **Restore**: a zero-filled `byte[sizeofShared]` plus a copy. Driver slots
+  beyond `numCars` are zeros, which is exactly what the game would have had for
+  them.
+
+### Blocks
+
+Records accumulate in memory and are flushed as a Brotli-compressed block once
+they span `BlockSeconds`. Blocks are independently decodable, and each block
+header carries its own compressed length.
+
+`BlockSeconds` is the compression-ratio versus seek-granularity dial, not a
+playback setting: smaller blocks seek more finely and grow the index but
+compress worse, since each block restarts the Brotli dictionary; larger blocks
+compress better but waste more decode per seek. In practice replay's backward
+seek always restarts at offset zero anyway, so the index matters mostly for
+loading, duration and the timeline.
+
+### Markers
+
+`markerType` is `PhaseChange` (value = the new `Constant.SessionPhase`) or
+`LapStart` (value = the completed-lap count at that point). They make
+"jump to lap N" cheap. There is no `SessionStart` marker — recording splits per
+session, so file start *is* session start.
+
+The recorder builds markers without marshalling anything, reading `SessionType`,
+`SessionPhase`, `TrackId` and `CompletedLaps` straight out of the raw buffer at
+offsets resolved once via `Marshal.OffsetOf`, the same trick `SharedMemoryService`
+already uses for `GameSimulationTicks`.
+
+### Crash recovery
+
+If YaHud is killed mid-recording, `indexOffset` is still zero and the trailing
+`YHTX` is absent. The reader then rebuilds the index by walking block headers —
+a seek-only scan, not a decode — and decodes only the final block to establish a
+sensible duration. Metadata still comes from the header, just as-of-first-frame
+rather than the footer's final summary. A killed session is never left
+unreadable.
+
+The reader always prefers the footer summary (`maxNumCars`, the observed class
+set) and falls back to header values when it is missing, because driver count
+and the set of car classes can both grow mid-session.
+
+### The version guard
+
+`sizeofShared`, `allDriversOffset` and `driverDataSize` are checked against the
+running build on open, and a mismatch **refuses loudly** with a message naming
+both layouts.
+
+This exists because `Shared` mirrors a layout owned by Sector3. When RaceRoom
+adds a field, `Marshal.SizeOf<Shared>()` changes and every field after the
+insertion point shifts. Without the guard, an old recording would not fail — it
+would misparse into plausible-looking garbage, which is a far worse outcome than
+a refusal. (The live UDP path has this weakness today: it only length-checks.)
+
+The consequence is that recordings are tied to the exact `Shared` layout. A
+future RaceRoom struct change invalidates old ones. The guard makes that loud;
+it does not make them forward-compatible.
+
+## Traps and limitations
+
+**`PlayerCarName` is not a car model name.** There is no car-name string
+anywhere in `Shared`. The field holds `VehicleInfo.Name`, which for the player
+slot is effectively the *driver* name — usually identical to `playerName`. If
+you need to identify the car, use **`PlayerCarModelId`**, which is reliable.
+
+**`frameCount` in a block index entry is a *record* count**, covering frames and
+start-lights alike, while the footer's `totalFrames` counts frame records only.
+They agree on a Windows recording with no start lights and on every Linux
+recording. On a **crashed** file, where the index was rebuilt by summing block
+`frameCount`s, `TotalFrames` therefore slightly overcounts by the number of
+start-light records in the file.
+
+**Start lights replay only from recordings made on Windows.** In-process replay
+makes the 400 Hz signal replayable in principle — `FileSharedSource` raises
+`StartLightsChanged` from the `StartLights` record type. But only
+`SharedMemoryService` raises the event in the first place;
+`RemoteSharedMemoryService` declares it and never fires it, so recordings
+captured on Linux (over the relay) contain **no start-light records at all**, and
+the StartLight widget behaves on replay exactly as it does live there. Fixing
+that means a typed envelope in the relay's UDP protocol — a separate concern.
+Start-light samples arriving before the first frame are also discarded: there is
+no file for them to land in yet.
+
+**Replay bypasses `RemoteSharedMemoryService`**, so it does not exercise the UDP
+receive path. Everything of interest lives above `ISharedSource`, but the
+relay/receiver code is not covered by replay testing.
+
+**No replaying into a second or remote HUD instance.** That is the price of
+dropping the UDP hop. The file format stays readable by a future standalone tool
+if that is ever wanted.
+
+**Seeks cost time, not accuracy.** See [Seek semantics](#seek-semantics). A
+backward seek replays from file start; the wall-clock cost of a long rewind has
+not been measured against real telemetry and is the main open question in this
+design.


### PR DESCRIPTION
## Summary
Adds the ability to record raw telemetry to disk and replay it back through the full HUD pipeline, entirely in-process - no separate application, no UDP hop.

- **Recording**: taps raw pre-marshal frame bytes off `ISharedSource` (covers both Windows shared memory and Linux UDP), truncates each frame's driver-data tail to the actual car count, and writes Brotli-compressed `.yhtl` files with a block index, timeline markers (lap starts, phase changes) and a footer summary. One file per session - recording auto-splits on session change, so file start is always session start. Crash-safe: a killed recording still loads by rebuilding the index from block headers.
- **Replay**: a third `ISharedSource` (`FileSharedSource`) swapped in at runtime via `SharedSourceSwitch`, so `TelemetryService` and every feature service are unaware they're replaying rather than live. `ReplayController` runs a target-seeking pump: forward seeks just consume frames from the current position (no reset needed, state is already correct); backward seeks reset and fast-replay from file start (files are split per session, so file start is session start). This is the design's central trick - YaHud only ever sees a monotonically forward frame stream, so no feature service needs any rewind-awareness.
- **Reset-path rework**: introduced an explicit `TelemetryReset` event (session change OR sim ticks going backwards), separated from `SessionTypeChanged`. Moved `SectorService`, `SimpleTimeGapService`, `TireWidgetService`, `RadarService` onto it, and fixed `FuelService` (it was subscribed to the wrong event and never reset fuel tracking on a rewind, live or replayed).
- **Config/CLI parity**: every recording/replay option is settable via launch argument or `appsettings.json` (`--record`/`YaHud:Recording:Enabled`, `--record-autostart`, `--recording-dir`, `--recording-block-seconds`, `--replay`/`YaHud:Replay:File`), following the same override pattern as the existing port options.
- **UI**: a `RecordReplay` widget - record controls, transport, scrubber, speed, jump-to-lap - always registered (so it's always configurable in the settings panel) but only rendered on the HUD when recording or replay is actually active. A recordings browser lives in the settings panel, showing track/session/car/class metadata per file without opening it. The widget can be docked to a screen edge as a slim hover-expand rail, so its controls keep working while the HUD is unlocked (docking registers no drag handler, unlike a free-floating widget).
- **Bug fixes found while dogfooding against a real recording** (not synthetic test data): the scrubber's `value` was bound reactively in Razor, so a still-playing replay's advancing position kept fighting the user's own drag in the browser; moved dragging, the live label and the thumb position entirely into JS, with only the `change` event on release reaching the server. Separately, `ReplayController`'s catch-up loop almost always overshoots an arbitrary seek target by a few milliseconds (frame timestamps rarely land exactly on it), which the pump misread as a brand new backward seek - rewinding to file start and repeating forever. Fixed by snapping the target onto the landed position in the same step that reaches it.

## Docs
- `docs/telemetry-recording.md` - format spec, how to record, how to replay
- `README.md` - run modes and launch flags
- `CONTRIBUTING.md` - recordings as the preferred way to reproduce widget bugs

## Test plan
- [x] `dotnet build R3E.slnx -c Release` on Windows - 0 errors
- [x] Recorded live telemetry, confirmed session-split files with correct per-file metadata
- [x] Loaded a real recording and drove it through the actual widget: play/pause, speed 0.1x-8x, frame step, jump-to-lap, scrubbing both forward and backward while playing
- [x] Verified rewind integrity: fuel consumption, tire age, sector state, and radar all correct after seeking backward past a pitstop
- [x] Verified exactness: values at a given point match whether reached by straight playback or by seeking away and back
- [x] Verified crash recovery (killed mid-recording, file still loads with a rebuilt index) and the version guard (a `Shared` layout mismatch refuses to load rather than rendering garbage)
- [x] Verified the widget is invisible on the HUD with recording/replay both off, but still configurable in the settings panel
- [x] Isolated `ReplayController` repro (no Blazor) confirming the seek/overshoot fix against a real recording
- [x] Confirmed no regression to normal (non-seeking) playback

🤖 Generated with [Claude Code](https://claude.com/claude-code)